### PR TITLE
refactor(radar): Converts `radar` into a computed property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-1.11
   - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,15 @@ language: node_js
 node_js:
   - "4"
 
-sudo: false
+sudo: required
+dist: trusty
+
+addons:
+  apt:
+    sources:
+    - google-chrome
+    packages:
+    - google-chrome-stable
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
   - npm config set spin false
   - npm install -g bower
   - npm install phantomjs-prebuilt

--- a/addon/-debug/edge-visualization/visualization.js
+++ b/addon/-debug/edge-visualization/visualization.js
@@ -101,13 +101,13 @@ export default class Visualization {
 
   styleViewport() {
     const {
-      itemContainer,
-      scrollContainer
+      _itemContainer,
+      _scrollContainer
     } = this.radar;
-    this.container.style.height = `${scrollContainer.getBoundingClientRect().height}px`;
+    this.container.style.height = `${_scrollContainer.getBoundingClientRect().height}px`;
 
-    Visualization.applyVerticalStyles(this.telescope, scrollContainer.getBoundingClientRect());
-    Visualization.applyVerticalStyles(this.sky, itemContainer.getBoundingClientRect());
+    Visualization.applyVerticalStyles(this.telescope, _scrollContainer.getBoundingClientRect());
+    Visualization.applyVerticalStyles(this.sky, _itemContainer.getBoundingClientRect());
 
     Visualization.applyVerticalStyles(this.screen, Container.getBoundingClientRect());
 
@@ -147,7 +147,7 @@ export default class Visualization {
   makeSatellites() {
     const {
       totalItems,
-      itemElements: { length }
+      orderedComponents: { length }
     } = this.radar;
     const { satellites } = this;
 
@@ -174,7 +174,7 @@ export default class Visualization {
     let {
       firstItemIndex,
       lastItemIndex,
-      totalItems,
+      items: { length },
       totalBefore,
       totalAfter,
       skipList: { values }
@@ -189,9 +189,9 @@ export default class Visualization {
       lastVisualizedIndex = totalVisualizedItems - 1;
     }
 
-    if (lastVisualizedIndex > totalItems - 1) {
-      lastVisualizedIndex = totalItems - 1;
-      firstVisualizedIndex = totalItems - totalVisualizedItems;
+    if (lastVisualizedIndex > length - 1) {
+      lastVisualizedIndex = length - 1;
+      firstVisualizedIndex = length - totalVisualizedItems;
     }
 
     for (let itemIndex = firstVisualizedIndex, i = 0; itemIndex <= lastVisualizedIndex; itemIndex++, i++) {

--- a/addon/-debug/helpers.js
+++ b/addon/-debug/helpers.js
@@ -38,7 +38,3 @@ export function deprecate() {
 export function stripInProduction(cb) {
   cb();
 }
-
-export function stripInModernEmber(cb) {
-  cb();
-}

--- a/addon/-private/data-view/radar/index.js
+++ b/addon/-private/data-view/radar/index.js
@@ -234,7 +234,7 @@ export default class Radar {
           virtualComponents.pushObject(component);
         }
       } else {
-        for (let i = virtualComponents.length; i > delta; i--) {
+        for (let i = virtualComponents.length - 1; i > delta; i--) {
           virtualComponents[i].destroy;
         }
       }

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -1,16 +1,12 @@
 import Radar from './index';
 
 export default class StaticRadar extends Radar {
-  constructor(options) {
-    super(options);
-  }
-
-  _update() {
-    const totalIndexes = this.itemElements.length;
+  _updateIndexes() {
+    const totalIndexes = this.orderedComponents.length;
     const maxIndex = this.totalItems - 1;
 
-    const middleVisibleValue = this.visibleTop + (this.scrollContainerHeight  / 2);
-    const middleItemIndex = Math.ceil(middleVisibleValue / this.minValue);
+    const middleVisibleValue = this.visibleTop + ((this.visibleBottom - this.visibleTop)  / 2);
+    const middleItemIndex = Math.ceil(middleVisibleValue / this.minHeight);
 
     let firstItemIndex = middleItemIndex - Math.floor((totalIndexes - 1) / 2);
     let lastItemIndex = middleItemIndex + Math.ceil((totalIndexes - 1) / 2);
@@ -30,15 +26,15 @@ export default class StaticRadar extends Radar {
   }
 
   get total() {
-    return this.totalItems * this.minValue;
+    return this.totalItems * this.minHeight;
   }
 
   get totalBefore() {
-    return this.firstItemIndex * this.minValue;
+    return this.firstItemIndex * this.minHeight;
   }
 
   get totalAfter() {
-    return this.total - (this.lastItemIndex * this.minValue);
+    return this.total - (this.lastItemIndex * this.minHeight);
   }
 
   get firstItemIndex() {
@@ -50,10 +46,10 @@ export default class StaticRadar extends Radar {
   }
 
   get firstVisibleIndex() {
-    return Math.ceil(this.visibleTop / this.minValue);
+    return Math.ceil(this.visibleTop / this.minHeight);
   }
 
   get lastVisibleIndex() {
-    return Math.ceil(this.visibleBottom / this.minValue);
+    return Math.ceil(this.visibleBottom / this.minHeight);
   }
 }

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -34,7 +34,6 @@ const VerticalCollection = Component.extend({
   boxStyle: htmlSafe(''),
 
   key: '@identity',
-  content: computed.deprecatingAlias('items'),
 
   // –––––––––––––– Required Settings
 
@@ -153,7 +152,7 @@ const VerticalCollection = Component.extend({
       _prevLastKey
     } = this;
 
-    const items = getArray(this.get('items'));
+    const items = getArray(this.get('items') || this.get('content'));
     const key = this.get('key');
     const lenDiff = items.length - (_prevItemsLength || 0);
 
@@ -189,8 +188,6 @@ const VerticalCollection = Component.extend({
     this.element.removeChild(this._virtualComponentRenderer);
 
     const containerSelector = this.get('containerSelector');
-
-    this.propertyDidChange('items.[]');
 
     if (containerSelector === 'body') {
       this._scrollContainer = Container;
@@ -244,7 +241,7 @@ const VerticalCollection = Component.extend({
     const key = this.get('key');
 
     const minHeight = this.get('_minHeight');
-    const items = this.get('items');
+    const items = this._items;
     const maxIndex = items.length;
 
     let index = 0;

--- a/addon/components/vertical-collection/template.hbs
+++ b/addon/components/vertical-collection/template.hbs
@@ -1,5 +1,5 @@
 <div class="virtual-component-renderer">
-  {{#each _virtualComponents key="id" as |virtualComponent|}}
+  {{#each radar.virtualComponents key="id" as |virtualComponent|}}
     {{{unbound virtualComponent.upperBound}}}
       {{yield virtualComponent.content virtualComponent.index}}
     {{{unbound virtualComponent.lowerBound}}}

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "smoke-and-mirrors",
   "dependencies": {
     "animation-frame": "~0.2.4",
-    "ember": "canary",
+    "ember": "1.13.13",
     "ember-cli-shims": "0.1.1"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -2,13 +2,13 @@
   "name": "smoke-and-mirrors",
   "dependencies": {
     "animation-frame": "~0.2.4",
-    "ember": "canary",
+    "ember": "beta",
     "ember-cli-shims": "0.1.1"
   },
   "devDependencies": {
     "bootstrap": "~3.3.5"
   },
   "resolutions": {
-    "ember": "canary"
+    "ember": "beta"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "smoke-and-mirrors",
   "dependencies": {
     "animation-frame": "~0.2.4",
-    "ember": "1.13.13",
+    "ember": "canary",
     "ember-cli-shims": "0.1.1"
   },
   "devDependencies": {

--- a/config/changelog.js
+++ b/config/changelog.js
@@ -1,4 +1,4 @@
-// jshint node:true
+/* eslint-env node */
 
 // For details on each option run `ember help release`
 module.exports = {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-env node */
 module.exports = {
   scenarios: [
     {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,6 +8,17 @@ module.exports = {
       }
     },
     {
+      name: 'ember-1.11',
+      bower: {
+        dependencies: {
+          'ember': '~1.11.0'
+        },
+        resolutions: {
+          'ember': '~1.11.0'
+        }
+      }
+    },
+    {
       name: 'ember-1.13',
       bower: {
         dependencies: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-env node */
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/config/release.js
+++ b/config/release.js
@@ -1,4 +1,4 @@
-/* jshint node:true */
+/* eslint-env node */
 // var RSVP = require('rsvp');
 var generateChangelog = require('ember-cli-changelog/lib/tasks/release-with-changelog');
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,4 @@
-/*jshint node:true*/
-/* global require, module */
-// jscs: disable
+/* eslint-env node */
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,5 +1,7 @@
 /* eslint-env node */
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+var VersionChecker = require('ember-cli-version-checker');
+var replace = require('broccoli-string-replace');
 
 module.exports = function(defaults) {
 
@@ -7,6 +9,15 @@ module.exports = function(defaults) {
   defaults.snippetPaths = ['tests/dummy/snippets'];
 
   var app = new EmberAddon(defaults);
+  var checker = new VersionChecker(app);
+
+  app.trees.tests = replace('tests', {
+    files: ['**/*'],
+    pattern: {
+      match: /\$\{\'items\'\}/g,
+      replacement: checker.forEmber().isAbove('1.13.0') ? 'items' : 'items=items'
+    }
+  });
 
   var bootstrapPath = app.bowerDirectory + '/bootstrap/dist/';
   app.import(bootstrapPath + 'css/bootstrap.css');

--- a/index.js
+++ b/index.js
@@ -48,9 +48,9 @@ module.exports = {
         filterImports(strippedModules),
         removeImports(importNames)
       );
-
-      this._hasSetupBabelOptions = true;
     }
+
+    this._hasSetupBabelOptions = true;
   },
 
   included: function(app) {

--- a/index.js
+++ b/index.js
@@ -7,14 +7,12 @@ var stripClassCallCheck = require('babel5-plugin-strip-class-callcheck');
 var filterImports = require('babel-plugin-filter-imports');
 var removeImports = require('./lib/babel-plugin-remove-imports');
 var Funnel = require('broccoli-funnel');
-var VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
   name: 'vertical-collection',
 
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
-    this.versionChecker = new VersionChecker(this);
 
     this.options = this.options || {};
   },
@@ -46,20 +44,14 @@ module.exports = {
         ]
       };
       importNames = ['vertical-collection/-debug/helpers'];
-    } else {
-      strippedModules = {
-        'vertical-collection/-debug/helpers': []
-      };
 
-      importNames = [];
+      babelOptions.plugins.push(
+        filterImports(strippedModules),
+        removeImports(importNames)
+      );
+
+      this._hasSetupBabelOptions = true;
     }
-
-    babelOptions.plugins.push(
-      filterImports(strippedModules),
-      removeImports(importNames)
-    );
-
-    this._hasSetupBabelOptions = true;
   },
 
   included: function(app) {

--- a/index.js
+++ b/index.js
@@ -54,10 +54,6 @@ module.exports = {
       importNames = [];
     }
 
-    if (this.versionChecker.forEmber().isAbove('1.13.0')) {
-      strippedModules['vertical-collection/-debug/helpers'].push('stripInModernEmber');
-    }
-
     babelOptions.plugins.push(
       filterImports(strippedModules),
       removeImports(importNames)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-// jscs: disable
-/* jshint node: true */
+/* eslint-env node */
 'use strict';
 
 var chalk = require('chalk');

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "broccoli-string-replace": "^0.1.2",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-changelog": "0.3.4",
@@ -37,6 +38,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cli-version-checker": "^1.2.0",
     "ember-code-snippet": "^1.1.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-env node */
 module.exports = {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",

--- a/tests/dummy/app/routes/examples/infinite-scroll/controller.js
+++ b/tests/dummy/app/routes/examples/infinite-scroll/controller.js
@@ -3,11 +3,13 @@ import getNumbers from 'dummy/lib/get-numbers';
 
 const {
   Controller
-  } = Ember;
+} = Ember;
 
 export default Controller.extend({
 
   numImages: 5,
+
+  someProperty: 50,
 
   actions: {
 
@@ -15,8 +17,8 @@ export default Controller.extend({
       let first = this.get('model.first');
       let numbers = getNumbers(first - 20, 20);
       let model = this.get('model.numbers');
-      let newModel =  numbers.concat(model);
-      this.set('model.numbers', newModel);
+      model.unshiftObjects(numbers);
+      // this.set('model.numbers', newModel);
       this.set('model.first', first - 20);
     },
 
@@ -24,11 +26,14 @@ export default Controller.extend({
       let last = this.get('model.last');
       let numbers = getNumbers(last, 20);
       let model = this.get('model.numbers');
-      let newModel =  model.concat(numbers);
-      this.set('model.numbers', newModel);
+      model.pushObjects(numbers);
+      // this.set('model.numbers', newModel);
       this.set('model.last', last + 20);
-    }
+    },
 
+    setMinHeight() {
+      this.set('someProperty', 90);
+    }
   }
 
 });

--- a/tests/dummy/app/routes/examples/infinite-scroll/route.js
+++ b/tests/dummy/app/routes/examples/infinite-scroll/route.js
@@ -8,7 +8,7 @@ const {
 export default Route.extend({
   model() {
     return {
-      numbers: getNumbers(0, 100),
+      numbers: Ember.A(getNumbers(0, 100)),
       first: 0,
       last: 100
     };

--- a/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
@@ -6,9 +6,9 @@
             <div class="table-wrapper dark">
               {{#vertical-collection
                 items=model.numbers
-                debug=true
-                minHeight=50
+                minHeight=someProperty
                 alwaysRemeasure=true
+                debug=true
                 firstReached="loadAbove"
                 lastReached="loadBelow"
                 as |item index|
@@ -33,6 +33,8 @@
               they return.
           </p>
             <h4>Code for Demo</h4>
+
+          <button {{action "setMinHeight"}}>Do it </button>
           {{!-- {{code-snippet name="infinite-scroll-example.hbs"}} --}}
         </div>
     </div>

--- a/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
@@ -4,7 +4,7 @@
             <h3>Demo</h3>
           {{!- BEGIN-SNIPPET infinite-scroll-example }}
             <div class="table-wrapper dark">
-              {{#vertical-collection
+              {{#vertical-collection model.numbers
                 items=model.numbers
                 minHeight=someProperty
                 alwaysRemeasure=true

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -9,7 +9,7 @@ module.exports = function(environment) {
     modulePrefix: 'dummy',
     podModulePrefix: 'dummy/routes',
     environment,
-    // rootURL: './vertical-collection/',
+    rootURL: '/',
     locationType: 'hash',
     EmberENV: {
       FEATURES: {},

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,6 +1,5 @@
-/* jshint node:true */
-// jscs:disable
-/* global module */
+/* eslint-env node */
+'use strict';
 let pkg = require('../../../package.json');
 
 module.exports = function(environment) {

--- a/tests/helpers/wait.js
+++ b/tests/helpers/wait.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
+
+export default function() {
+  return wait().then(() => {
+    return new Ember.RSVP.Promise((resolve) => {
+      requestAnimationFrame(resolve);
+    });
+  });
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -14,6 +14,12 @@
     <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
+    <style>
+      #ember-testing {
+        transform: scale(1.0);
+      }
+    </style>
+
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>

--- a/tests/integration/components/vertical-collection-test.js
+++ b/tests/integration/components/vertical-collection-test.js
@@ -19,8 +19,7 @@ test('The Collection Renders', function(assert) {
   // Template block usage:
   this.render(hbs`
   <div style="height: 500px; width: 500px;">
-    {{#vertical-collection items
-      items=items
+    {{#vertical-collection ${'items'}
 
       as |item|}}
       <vertical-item>
@@ -45,8 +44,7 @@ test('The Collection Renders when content is empty', function(assert) {
   // Template block usage:
   this.render(hbs`
   <div style="height: 500px; width: 500px;">
-    {{#vertical-collection items
-      items=items
+    {{#vertical-collection ${'items'}
 
       as |item|}}
       <vertical-item>
@@ -68,8 +66,7 @@ test('Scroll to last item when actual item sizes are significantly larger than d
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection items
-      items=items
+    {{#vertical-collection ${'items'}
       minHeight=10
       alwaysRemeasure=true
 
@@ -111,8 +108,7 @@ test('Sends the last visible changed action', function(assert) {
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection items
-      items=items
+    {{#vertical-collection ${'items'}
       minHeight=20
       lastVisibleChanged="lastVisibleChanged"
 
@@ -144,8 +140,7 @@ test('Sends the first visible changed action', function(assert) {
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection items
-      items=items
+    {{#vertical-collection ${'items'}
       minHeight=20
       firstVisibleChanged="firstVisibleChanged"
 
@@ -166,8 +161,7 @@ test('Collection prepends via set correctly', function(assert) {
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection items
-      items=items
+    {{#vertical-collection ${'items'}
       minHeight=20
 
       as |item i|}}
@@ -200,8 +194,7 @@ test('Collection prepends via unshiftObjects correctly', function(assert) {
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection items
-      items=items
+    {{#vertical-collection ${'items'}
       minHeight=20
 
       as |item i|}}

--- a/tests/integration/components/vertical-collection-test.js
+++ b/tests/integration/components/vertical-collection-test.js
@@ -3,6 +3,8 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
+import getNumbers from 'dummy/lib/get-numbers';
+
 moduleForComponent('vertical-collection', 'Integration | Component | vertical collection', {
   integration: true
 });
@@ -17,7 +19,7 @@ test('The Collection Renders', function(assert) {
   // Template block usage:
   this.render(hbs`
   <div style="height: 500px; width: 500px;">
-    {{#vertical-collection content=items as |item|}}
+    {{#vertical-collection items=items as |item|}}
       <vertical-item>
         {{item.text}}
       </vertical-item>
@@ -40,7 +42,7 @@ test('The Collection Renders when content is empty', function(assert) {
   // Template block usage:
   this.render(hbs`
   <div style="height: 500px; width: 500px;">
-    {{#vertical-collection content=items as |item|}}
+    {{#vertical-collection items=items as |item|}}
       <vertical-item>
         {{item.text}}
       </vertical-item>
@@ -62,7 +64,8 @@ test('Scroll to last item when actual item sizes are significantly larger than d
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection
       minHeight=10
-      content=items as |item i|}}
+      alwaysRemeasure=true
+      items=items as |item i|}}
       <div style="height: 100px;">{{item.text}} {{i}}</div>
     {{/vertical-collection}}
   </div>
@@ -83,29 +86,165 @@ test('Scroll to last item when actual item sizes are significantly larger than d
     });
 });
 
-// test('Sends the last visible changed action', function(assert) {
-//   const done = assert.async();
+test('Sends the last visible changed action', function(assert) {
+  const called = assert.async(2);
+  let count = 0;
 
-//   this.set('items', Array(50).fill({ text: 'b' }));
-//   this.on('lastVisibleChanged', (item) => {
-//     assert.equal(item.index, 30, 'the last visible changed should be item 30');
-//     done();
-//   });
+  this.set('items', Array(50).fill({ text: 'b' }));
+  this.on('lastVisibleChanged', (item, index) => {
+    if (count === 0) {
+      assert.equal(index, 10, 'the first last visible changed should be item 10');
+    } else {
+      assert.equal(index, 20, 'after scroll the last visible change should be item 20');
+    }
+    count++;
+    called();
+  });
+
+  this.render(hbs`
+  <div style="height: 200px; width: 100px;" class="scrollable">
+    {{#vertical-collection
+      minHeight=20
+      items=items
+      lastVisibleChanged='lastVisibleChanged' as |item|}}
+      <div style="height:20px;">
+        {{item.text}} {{i}}
+      </div>
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  wait().then(() => this.$('.scrollable').scrollTop(200));
+});
+
+test('Sends the first visible changed action', function(assert) {
+  const called = assert.async(2);
+  let count = 0;
+
+  this.set('items', Array(50).fill({ text: 'b' }));
+  this.on('firstVisibleChanged', (item, index) => {
+    if (count === 0) {
+      assert.equal(index, 0, 'the first last visible changed should be item 0');
+    } else {
+      assert.equal(index, 10, 'after scroll the last visible change should be item 10');
+    }
+    count++;
+    called();
+  });
+
+  this.render(hbs`
+  <div style="height: 200px; width: 100px;" class="scrollable">
+    {{#vertical-collection
+      minHeight=20
+      items=items
+      firstVisibleChanged='firstVisibleChanged' as |item|}}
+      <div style="height:20px;">
+        {{item.text}} {{i}}
+      </div>
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  wait().then(() => this.$('.scrollable').scrollTop(200));
+});
+
+test('Collection prepends via set correctly', function(assert) {
+  assert.expect(4);
+  this.set('items', getNumbers(0, 100));
+
+  this.render(hbs`
+  <div style="height: 200px; width: 100px;" class="scrollable">
+    {{#vertical-collection
+      minHeight=20
+      items=items
+
+      as |item i|}}
+      <div style="height:20px;">
+        {{item.number}} {{i}}
+      </div>
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  const scrollable = this.$('.scrollable');
+
+  return wait().then(() => {
+    assert.equal(scrollable.find('div:first').text().trim(), '0 0', 'items rendered correctly');
+    assert.equal(scrollable.scrollTop(), 0, 'scrollTop is correct before prepend');
+
+    const newNumbers = getNumbers(-20, 20).concat(this.get('items'));
+    this.set('items', newNumbers);
+
+    return wait();
+  }).then(() => {
+    assert.equal(scrollable.find('div:first').text().trim(), '-10 10', 'items prepended and rendered correctly');
+    assert.equal(scrollable.scrollTop(), 400, 'scrollTop is correct after prepend');
+  });
+});
+
+test('Collection prepends via unshiftObjects correctly', function(assert) {
+  assert.expect(4);
+  this.set('items', Ember.A(getNumbers(0, 100)));
+
+  this.render(hbs`
+  <div style="height: 200px; width: 100px;" class="scrollable">
+    {{#vertical-collection
+      minHeight=20
+      items=items
+
+      as |item i|}}
+      <div style="height:20px;">
+        {{item.number}} {{i}}
+      </div>
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  const scrollable = this.$('.scrollable');
+
+  return wait().then(() => {
+    assert.equal(scrollable.find('div:first').text().trim(), '0 0', 'items rendered correctly');
+    assert.equal(scrollable.scrollTop(), 0, 'scrollTop is correct before prepend');
+
+    this.get('items').unshiftObjects(getNumbers(-20, 20));
+
+    return wait();
+  }).then(() => {
+    assert.equal(scrollable.find('div:first').text().trim(), '-10 10', 'items prepended and rendered correctly');
+    assert.equal(scrollable.scrollTop(), 400, 'scrollTop is correct after prepend');
+  });
+});
+
+// test('Collection prepends correctly if prepend would cause more VCs to be shown', function(assert) {
+//   assert.async();
+//   this.set('items', getNumbers(0, 20));
 
 //   this.render(hbs`
 //   <div style="height: 200px; width: 100px;" class="scrollable">
 //     {{#vertical-collection
 //       minHeight=10
-//       content=items
-//       lastVisibleChanged='lastVisibleChanged' as |item|}}
+//       items=items
+
+//       as |item i|}}
 //       <div style="height:20px;">
-//         {{item.text}} {{i}}
+//         {{item.number}} {{i}}
 //       </div>
 //     {{/vertical-collection}}
 //   </div>
 //   `);
 
-//   wait().then(() => this.$('.scrollable').scrollTop(100));
+//   wait().then(() => {
+//     const newNumbers = getNumbers(-20, 20).concat(this.get('items'));
+//     this.set('items', newNumbers);
+
+//     return wait();
+//   }).then(() => {
+
+//     const scrollable = this.$('.scrollable');
+
+//     assert.equal(scrollable.find('div:first').html(), '-10', 'items prepended and rendered correctly');
+//     assert.equal(scrollable.scrollTop(), 200, 'scrollTop is correct after prepend');
+//   });
 // });
 
 /*

--- a/tests/integration/components/vertical-collection-test.js
+++ b/tests/integration/components/vertical-collection-test.js
@@ -1,9 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
-import wait from 'ember-test-helpers/wait';
 
 import getNumbers from 'dummy/lib/get-numbers';
+import wait from '../../helpers/wait';
 
 moduleForComponent('vertical-collection', 'Integration | Component | vertical collection', {
   integration: true

--- a/tests/integration/components/vertical-collection-test.js
+++ b/tests/integration/components/vertical-collection-test.js
@@ -19,7 +19,10 @@ test('The Collection Renders', function(assert) {
   // Template block usage:
   this.render(hbs`
   <div style="height: 500px; width: 500px;">
-    {{#vertical-collection items=items as |item|}}
+    {{#vertical-collection items
+      items=items
+
+      as |item|}}
       <vertical-item>
         {{item.text}}
       </vertical-item>
@@ -42,7 +45,10 @@ test('The Collection Renders when content is empty', function(assert) {
   // Template block usage:
   this.render(hbs`
   <div style="height: 500px; width: 500px;">
-    {{#vertical-collection items=items as |item|}}
+    {{#vertical-collection items
+      items=items
+
+      as |item|}}
       <vertical-item>
         {{item.text}}
       </vertical-item>
@@ -62,10 +68,12 @@ test('Scroll to last item when actual item sizes are significantly larger than d
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection
+    {{#vertical-collection items
+      items=items
       minHeight=10
       alwaysRemeasure=true
-      items=items as |item i|}}
+
+      as |item i|}}
       <div style="height: 100px;">{{item.text}} {{i}}</div>
     {{/vertical-collection}}
   </div>
@@ -103,10 +111,12 @@ test('Sends the last visible changed action', function(assert) {
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection
-      minHeight=20
+    {{#vertical-collection items
       items=items
-      lastVisibleChanged='lastVisibleChanged' as |item|}}
+      minHeight=20
+      lastVisibleChanged="lastVisibleChanged"
+
+      as |item|}}
       <div style="height:20px;">
         {{item.text}} {{i}}
       </div>
@@ -134,10 +144,12 @@ test('Sends the first visible changed action', function(assert) {
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection
-      minHeight=20
+    {{#vertical-collection items
       items=items
-      firstVisibleChanged='firstVisibleChanged' as |item|}}
+      minHeight=20
+      firstVisibleChanged="firstVisibleChanged"
+
+      as |item|}}
       <div style="height:20px;">
         {{item.text}} {{i}}
       </div>
@@ -154,9 +166,9 @@ test('Collection prepends via set correctly', function(assert) {
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection
-      minHeight=20
+    {{#vertical-collection items
       items=items
+      minHeight=20
 
       as |item i|}}
       <div style="height:20px;">
@@ -188,9 +200,9 @@ test('Collection prepends via unshiftObjects correctly', function(assert) {
 
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection
-      minHeight=20
+    {{#vertical-collection items
       items=items
+      minHeight=20
 
       as |item i|}}
       <div style="height:20px;">
@@ -258,7 +270,7 @@ test("The Collection Reveals it's children when `renderAllInitially` is true.", 
   // Template block usage:
   this.render(hbs`
   <div style="height: 500px; width: 500px;">
-    {{#vertical-collection content=items renderAllInitially=true as |item|}}
+    {{#vertical-collection items=items renderAllInitially=true as |item|}}
       {{item.text}}
     {{/vertical-collection}}
   </div>


### PR DESCRIPTION
It turns out that `radar` needs to be a computed property in order to respond to array mutations. Something in the template itself has to be bound in order for radar to be recomputed, and as the only thing that is bound at all is `virtualComponents`, they needed to be moved into `radar` proper to put it on the refresh path.