### PR TITLE
refactor(measure): Simplifies measurement and only measures when necessary

### DIFF
--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -2,6 +2,10 @@ import Radar from './index';
 
 export default class StaticRadar extends Radar {
   _updateIndexes() {
+    const {
+      _firstItemIndex: prevFirstItemIndex
+    } = this;
+
     const totalIndexes = this.orderedComponents.length;
     const maxIndex = this.totalItems - 1;
 
@@ -23,6 +27,8 @@ export default class StaticRadar extends Radar {
 
     this._firstItemIndex = firstItemIndex;
     this._lastItemIndex = lastItemIndex;
+
+    return firstItemIndex - prevFirstItemIndex;
   }
 
   get total() {
@@ -41,8 +47,16 @@ export default class StaticRadar extends Radar {
     return this._firstItemIndex;
   }
 
+  set firstItemIndex(index) {
+    this._firstItemIndex = index;
+  }
+
   get lastItemIndex() {
     return this._lastItemIndex;
+  }
+
+  set lastItemIndex(index) {
+    this._lastItemIndex = index;
   }
 
   get firstVisibleIndex() {

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -77,6 +77,9 @@ export default class SkipList {
     }
 
     this.total = layer.length > 0 ? layer.length > 1 ? layer[0] + layer[1] : layer[0] : 0;
+
+    assert('total must be a number', typeof this.total === 'number');
+
     this.layers = layers;
     this.values = values;
   }
@@ -92,6 +95,7 @@ export default class SkipList {
 
     targetValue = Math.min(total, targetValue);
 
+    assert('targetValue must be a number', typeof targetValue === 'number');
     assert('targetValue must be greater than or equal to 0', targetValue >= 0);
     assert('targetValue must be no more than total', targetValue <= total);
 
@@ -122,6 +126,10 @@ export default class SkipList {
   }
 
   set(index, value) {
+    assert('value must be a number', typeof value === 'number');
+    assert('index must be a number', typeof index === 'number');
+    assert('index must be within bounds', index >= 0 && index < this.values.length);
+
     const { layers } = this;
     const oldValue = layers[layers.length - 1][index];
     const delta = value - oldValue;

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -21,6 +21,7 @@ export default class VirtualComponent {
     this.height = 0;
     this.range = doc.createRange();
     this.content = null;
+    this.inDOM = false;
     this.token = new Token(parentToken);
   }
 
@@ -37,30 +38,22 @@ export default class VirtualComponent {
   }
 
   getBoundingClientRect() {
-    if (!this.rect) {
-      this.range.setStart(this._upperBound, 0);
-      this.range.setEnd(this._lowerBound, 0);
+    this.range.setStart(this._upperBound, 0);
+    this.range.setEnd(this._lowerBound, 0);
 
-      this.rect = this.range.getBoundingClientRect();
+    const rect = this.range.getBoundingClientRect();
 
-      this.range.detach();
-    }
+    this.range.detach();
 
-    return this.rect;
-  }
-
-  static create(parentToken) {
-    return new VirtualComponent(parentToken);
+    return rect;
   }
 
   recycle(newContent, newIndex) {
     assert(`You cannot set an item's content to undefined`, newContent);
 
     set(this, 'index', newIndex);
-    this.rect = null;
 
     if (this.content !== newContent) {
-      this.hasBeenMeasured = false;
       set(this, 'content', newContent);
     }
   }
@@ -74,6 +67,10 @@ export default class VirtualComponent {
     this._lowerBound = null;
 
     set(this, 'content', null);
+  }
+
+  static create(parentToken) {
+    return new VirtualComponent(parentToken);
   }
 
   static moveComponents(element, firstComponent, lastComponent, prepend) {

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -107,13 +107,15 @@ const VerticalCollection = Component.extend({
   }),
 
   isEmpty: computed.empty('items'),
+
   supportsInverse: computed(function() {
     // This is not a direct semver comparison, just a standard JS String comparison.
     // It happens to work for the cases we need to compare (since we don't support < 1.11)
     return VERSION >= '1.13.0';
   }),
-  supportsActionsInYield: computed.alias('supportsInverse'),
+
   shouldYieldToInverse: computed.and('isEmpty', 'supportsInverse'),
+
   _sendActions() {
     const {
       _items,

--- a/addon/components/vertical-collection/template.hbs
+++ b/addon/components/vertical-collection/template.hbs
@@ -1,18 +1,10 @@
 <div class="virtual-component-renderer">
   {{#each radar.virtualComponents key="id" as |virtualComponent|}}
     {{{unbound virtualComponent.upperBound}}}
-      {{#if supportsActionsInYield}}
-        {{yield
-          virtualComponent.content
-          virtualComponent.index
-          (action 'heightDidChange' virtualComponent)
-        }}
-      {{else}}
-        {{yield
-          virtualComponent.content
-          virtualComponent.index
-        }}
-      {{/if}}
+      {{yield
+        virtualComponent.content
+        virtualComponent.index
+      }}
     {{{unbound virtualComponent.lowerBound}}}
   {{/each}}
 </div>

--- a/tests/dummy/app/routes/examples/scrollable-body/template.hbs
+++ b/tests/dummy/app/routes/examples/scrollable-body/template.hbs
@@ -4,9 +4,9 @@
           {{!- BEGIN-SNIPPET scrollable-body-example }}
           {{#vertical-collection model.numbers
             minHeight=40
+            alwaysRemeasure=true
             containerSelector="body"
             indexForFirstItem=20
-            renderFromLast=true
             as |item index|
             }}
               {{number-slide item=item index=index}}

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -40,7 +40,7 @@ nav a {
 
 .table-wrapper, .scrollable {
   display: block;
-  height: 500px;
+  height: 1000px;
   max-height: 500px;
   overflow: scroll;
   -webkit-overflow-scrolling: touch;

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -1,0 +1,88 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+import wait from 'dummy/tests/helpers/wait';
+import getNumbers from 'dummy/lib/get-numbers';
+
+moduleForComponent('vertical-collection', 'Integration | Measure Tests', {
+  integration: true
+});
+
+test('The collection correctly remeasures items when scrolling down', function(assert) {
+  assert.expect(2);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('items', Ember.A(getNumbers(0, 100)));
+
+  // Template block usage:
+  this.render(hbs`
+  <div style="height: 200px; width: 100px;" class="scrollable">
+    {{#vertical-collection ${'items'}
+      alwaysRemeasure=true
+      minHeight=20
+
+      as |item|}}
+      <div class="item" style="height: 20px;">
+        {{item.number}}
+      </div>
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  const scrollContainer = this.$('.scrollable');
+  const itemContainer = this.$('vertical-collection');
+
+  return wait().then(() => {
+    assert.equal(itemContainer.css('paddingTop'), '0px', 'itemContainer padding is correct on initial render');
+    this.$('.item:first').height(50);
+
+    scrollContainer.scrollTop(251);
+
+    return wait();
+  }).then(() => {
+    assert.equal(itemContainer.css('paddingTop'), '50px', 'itemContainer padding is the height of the modified first element');
+  });
+});
+
+test('The collection correctly remeasures items when scrolling up', function(assert) {
+  assert.expect(3);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('items', Ember.A(getNumbers(0, 100)));
+
+  // Template block usage:
+  this.render(hbs`
+  <div style="height: 200px; width: 100px;" class="scrollable">
+    {{#vertical-collection ${'items'}
+      alwaysRemeasure=true
+      minHeight=20
+
+      as |item|}}
+      <div class="item" style="height: 20px;">
+        {{item.number}}
+      </div>
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  const scrollContainer = this.$('.scrollable');
+  const itemContainer = this.$('vertical-collection');
+
+  return wait().then(() => {
+    assert.equal(itemContainer.css('paddingBottom'), '1380px', 'itemContainer padding is correct on initial render');
+    scrollContainer.scrollTop(221);
+
+    return wait();
+  }).then(() => {
+    assert.equal(itemContainer.css('paddingBottom'), '1360px', 'itemContainer padding is correct after scrolling down');
+    this.$('.item:last').height(50);
+    scrollContainer.scrollTop(0);
+
+    return wait();
+  }).then(() => {
+    assert.equal(itemContainer.css('paddingBottom'), '1410px', 'itemContainer padding has the height of the modified last element');
+  });
+});

--- a/tests/integration/modern-ember-test.js
+++ b/tests/integration/modern-ember-test.js
@@ -2,7 +2,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-import getNumbers from 'dummy/lib/get-numbers';
 import wait from 'dummy/tests/helpers/wait';
 
 if (Ember.VERSION >= '1.13.0') {
@@ -24,44 +23,5 @@ if (Ember.VERSION >= '1.13.0') {
       const el = this.$('vertical-collection');
       assert.equal(el.html().trim(), 'Foobar');
     });
-  });
-
-  test('Collection measures correctly after firing heightDidChange', function(assert) {
-    assert.expect(2);
-
-    let firstItem;
-    const items = getNumbers(0, 20);
-
-    this.set('items', items.map((item) => {
-      item.height = 100;
-      return item;
-    }));
-
-    this.render(hbs`
-      <div style="height: 200px; width: 200px;" class="scroll-parent scrollable">
-        {{#vertical-collection ${'items'}
-          alwaysRemeasure=true
-          as |item i heightDidChange|}}
-          {{number-slide
-            item=item
-            index=index
-            incrementBy=250
-            didResize=heightDidChange
-          }}
-        {{/vertical-collection}}
-      </div>
-    `);
-    return wait()
-      .then(() => {
-        firstItem = this.$('number-slide').get(0);
-        firstItem.click(); // item height will now be 350
-        return wait();
-      }).then(() => {
-        assert.equal(firstItem.style.height, '350px');
-        this.$('.scrollable')[0].scrollTop += 750;
-        return wait();
-      }).then(() => {
-        assert.equal(this.$('vertical-collection')[0].style.paddingTop, '350px');
-      });
   });
 }


### PR DESCRIPTION
This PR simplifies the current state management for measuring VCs. They no longer cache data   about their geometry or measure state. Additionally, it changes the logic surrounding measurement in general. We now measure in three phases:

1. We measure the all items just before we make any changes or measurements. This is to capture any possible changes that could have happened while items were rendered.
2. If necessary we measure the items that could affect the scroll position post-render (e.g. if we are scroll up). This occurs after the Radar's update phase (RAF 'measure').
3. We use `run.next` to defer a full measurement of all items until after the RAF, making sure the extra work doesn't block us.

There is also a minor perf improvement, we no longer add `_prependOffset` in the sync phase. Instead, we coalesce any changes that could have occurred in the measure phase into the offset and set it once. This means that we have, at most, 1 forced layout per update, and only when we are scrolling upwards.