### PR TITLE
perf(actions): Defers action sending until after RAF

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -20,6 +20,7 @@ import {
 const {
   computed,
   Component,
+  run,
   String: { htmlSafe },
   VERSION
 } = Ember;
@@ -308,7 +309,7 @@ const VerticalCollection = Component.extend({
     this._radar = new RadarClass();
 
     this._radar.didUpdate = () => {
-      this._sendActions();
+      run.next(() => this._sendActions());
     };
   },
   actions: {


### PR DESCRIPTION
Sending actions can trigger a lot of things, including more rendering. We should defer that work until after the RAF has finished.