### PR TITLE
feature(resize): Adds a resize event

### DIFF
--- a/addon/-private/data-view/utils/resize-handler.js
+++ b/addon/-private/data-view/utils/resize-handler.js
@@ -1,0 +1,167 @@
+const DEFAULT_ARRAY_SIZE = 10;
+
+export class ResizeHandler {
+  constructor() {
+    this.elements = new Array(DEFAULT_ARRAY_SIZE);
+    this.maxLength = DEFAULT_ARRAY_SIZE;
+    this.length = 0;
+    this.handlers = new Array(DEFAULT_ARRAY_SIZE);
+  }
+
+  addResizeHandler(element, handler) {
+    let index = this.elements.indexOf(element);
+    let handlers, cache;
+
+    if (index === -1) {
+      index = this.length++;
+
+      if (index === this.maxLength) {
+        this.maxLength *= 2;
+        this.elements.length = this.maxLength;
+        this.handlers.length = this.maxLength;
+      }
+
+      handlers = [handler];
+
+      this.elements[index] = element;
+
+      cache = this.handlers[index] = {
+        top: element.scrollTop,
+        left: element.scrollLeft,
+        handlers
+      };
+    } else {
+      cache = this.handlers[index];
+      handlers = cache.handlers;
+      handlers.push(handler);
+    }
+
+    if (handlers.length === 1) {
+      if (element === window) {
+        cache.handler = function() {
+          ResizeHandler.triggerElementHandlers(cache);
+        };
+
+        element.addEventListener('resize', cache.handler, { capture: true, passive: true });
+      } else {
+        const parentStyle = `
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          overflow: hidden;
+          z-index: -1;
+          visibility: hidden;
+        `;
+
+        const childStyle = `
+          position: absolute;
+          top: 0;
+          left: 0;
+          transition: 0s;
+        `;
+
+        // Needs to be a position that can be absolutely positioned against
+        if (getComputedStyle(element, 'position') == 'static') {
+          element.style.position = 'relative';
+        }
+
+        const resizeSensor = document.createElement('div');
+
+        resizeSensor.className = 'resize-sensor';
+        resizeSensor.cssText = parentStyle;
+        resizeSensor.innerHTML = `
+          <div class="resize-sensor-expand" style="${parentStyle}">
+            <div style="${childStyle} width: 1000000px; height: 1000000px;"></div>
+          </div>
+          <div class="resize-sensor-shrink" style="${parentStyle}">
+            <div style="${childStyle} width: 200%; height: 200%"></div>
+          </div>
+        `;
+
+        // ES Lint disable because suave wants to destructure these, but aren't always destructurable
+        const expand = resizeSensor.getElementsByClassName('resize-sensor-expand')[0]; // eslint-disable-line
+        const shrink = resizeSensor.getElementsByClassName('resize-sensor-shrink')[0]; // eslint-disable-line
+
+        element.appendChild(resizeSensor);
+
+        expand.scrollTop = 10000000;
+        expand.scrollLeft = 10000000;
+        shrink.scrollTop = 10000000;
+        shrink.scrollLeft = 10000000;
+
+        cache.expand = expand;
+        cache.shrink = shrink;
+        cache.handler = function() {
+          expand.scrollTop = 10000000;
+          expand.scrollLeft = 10000000;
+          shrink.scrollTop = 10000000;
+          shrink.scrollLeft = 10000000;
+
+          ResizeHandler.triggerElementHandlers(cache);
+        };
+
+        expand.addEventListener('scroll', cache.handler, { capture: true, passive: true });
+        shrink.addEventListener('scroll', cache.handler, { capture: true, passive: true });
+      }
+    }
+  }
+
+  removeResizeHandler(element, handler) {
+    let index = this.elements.indexOf(element);
+    let elementCache = this.handlers[index];
+
+    if (elementCache && elementCache.handlers) {
+      let index = elementCache.handlers.indexOf(handler);
+
+      if (index === -1) {
+        throw new Error('Attempted to remove an unknown handler');
+      }
+
+      elementCache.handlers.splice(index, 1);
+
+      // cleanup element entirely if needed
+      if (!elementCache.handlers.length) {
+        index = this.elements.indexOf(element);
+        this.handlers.splice(index, 1);
+        this.elements.splice(index, 1);
+
+        this.length--;
+        this.maxLength--;
+
+        if (this.length === 0) {
+          this.isPolling = false;
+        }
+
+        if (element === window) {
+          element.removeEventListener('resize', elementCache.handler, { capture: true, passive: true });
+        } else {
+          elementCache.expand.removeEventListener('scroll', elementCache.handler, { capture: true, passive: true });
+          elementCache.shrink.removeEventListener('scroll', elementCache.handler, { capture: true, passive: true });
+        }
+      }
+
+    } else {
+      throw new Error('Attempted to remove a handler from an unknown element or an element with no handlers');
+    }
+  }
+
+  static triggerElementHandlers(meta) {
+    for (let j = 0; j < meta.handlers.length; j++) {
+      meta.handlers[j]();
+    }
+  }
+}
+
+const instance = new ResizeHandler();
+
+export function addResizeHandler(element, handler) {
+  instance.addResizeHandler(element, handler);
+}
+
+export function removeResizeHandler(element, handler) {
+  instance.removeResizeHandler(element, handler);
+}
+
+export default instance;

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -12,10 +12,8 @@ import StaticRadar from 'vertical-collection/-private/data-view/radar/static-rad
 
 import Container from 'vertical-collection/-private/data-view/container';
 import getArray from 'vertical-collection/-private/data-view/utils/get-array';
-import {
-  addScrollHandler,
-  removeScrollHandler
-} from 'vertical-collection/-private/data-view/utils/scroll-handler';
+import { addScrollHandler, removeScrollHandler } from 'vertical-collection/-private/data-view/utils/scroll-handler';
+import { addResizeHandler, removeResizeHandler } from 'vertical-collection/-private/data-view/utils/resize-handler';
 
 const {
   computed,
@@ -289,17 +287,24 @@ const VerticalCollection = Component.extend({
       }
     };
 
-    this._resizeHandler = () => {
-      this._initializeRadar();
+    this._itemContainerResizeHandler = () => {
+      this._radar.scheduleUpdate();
+    };
+
+    this._windowResizeHandler = () => {
+      this._radar.scrollContainer = this._scrollContainer;
+      this._radar.scheduleUpdate();
     };
 
     addScrollHandler(this._scrollContainer, this._scrollHandler);
-    Container.addEventListener('resize', this._resizeHandler);
+    addResizeHandler(this.element, this._itemContainerResizeHandler);
+    addResizeHandler(window, this._windowResizeHandler);
   },
 
-  willDestroy() {
+  willRemoveElement() {
     removeScrollHandler(this._scrollContainer, this._scrollHandler);
-    Container.removeEventListener('resize', this._resizeHandler);
+    removeResizeHandler(this.element, this._itemContainerResizeHandler);
+    removeResizeHandler(window, this._windowResizeHandler);
   },
 
   init() {

--- a/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
@@ -14,7 +14,6 @@
             {{number-slide
               item=item
               index=index
-              isDynamic=false
             }}
           {{/vertical-collection}}
         </div>


### PR DESCRIPTION
Even when we are always remeasuring, there is an edge case that we can't easily account for. If a large number of items are rendered, and then all of them are shrunk (or even one very large item is shrunk), it's possible that A. no scroll event is fired (sometimes it happens when we resize items, sometimes it doesn't) and B. the buffers aren't large enough to account for the delta, and we end up showing the padding below.

This adds a "resize" event based on [the concept found here](https://github.com/marcj/css-element-queries/blob/master/src/ResizeSensor.js)

The basic idea is you listen to the scroll event on a hidden container that is a child of the element you are trying to measure, with `width: 100%` and `height: 100%`. It has a child with a very large height/width, and when it resizes the scroll bars change size triggering the scroll event.

This is pretty hack-y, but it seems to be the best solution out there. It's worth noting that I had to follow the exact configuration here, with two child elements both having scroll listeners - it was possible to trip anything else up for some reason 😕 . I'm also not entirely sure how to test this, given it's based on some pretty finicky browser behavior that could change from version to version (that is, specifically what types of resizes will _not_ trigger a scroll on the `itemContainer`).

Also worth noting that this alone is not enough to fully cover measuring when elements are resized, there's the edge case where multiple items are resized but equal the same height in the end. That case may be rare enough that we could drop the pre-measurement behavior (or atleast make it optional).