### PR TITLE
refactor(api): Change alwaysRemeasure to staticHeight

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -45,8 +45,7 @@ const VerticalCollection = Component.extend({
   items: null,
 
   // –––––––––––––– Optional Settings
-  alwaysRemeasure: false,
-  alwaysUseDefaultHeight: computed.not('alwaysRemeasure'),
+  staticHeight: false,
 
   /*
    * A selector string that will select the element from
@@ -304,7 +303,7 @@ const VerticalCollection = Component.extend({
     console.time('vertical-collection-init'); // eslint-disable-line no-console
     this._super();
 
-    const RadarClass = this.get('alwaysRemeasure') ? DynamicRadar : StaticRadar;
+    const RadarClass = this.get('staticHeight') ? StaticRadar : DynamicRadar;
 
     this._radar = new RadarClass();
 

--- a/tests/dummy/app/routes/examples/dbmon/template.hbs
+++ b/tests/dummy/app/routes/examples/dbmon/template.hbs
@@ -10,6 +10,7 @@
                 containerSelector=".table-wrapper"
                 tagName="tbody"
                 minHeight=37
+                staticHeight=true
 
                 as |db|
               }}

--- a/tests/dummy/app/routes/examples/flexible-layout/template.hbs
+++ b/tests/dummy/app/routes/examples/flexible-layout/template.hbs
@@ -6,7 +6,6 @@
         <div class="table-wrapper dark">
           {{#vertical-collection model.numbers
             minHeight=270
-            alwaysRemeasure=true
             firstReached="loadAbove"
             lastReached="loadBelow"
             as |item index|

--- a/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
@@ -6,6 +6,7 @@
         <div class="table-wrapper dark">
           {{#vertical-collection model.numbers
             minHeight=90
+            staticHeight=true
             firstReached="loadAbove"
             lastReached="loadBelow"
             as |item index|

--- a/tests/dummy/app/routes/examples/reduce-debug/template.hbs
+++ b/tests/dummy/app/routes/examples/reduce-debug/template.hbs
@@ -6,7 +6,6 @@
             {{#vertical-collection
               content=model.filtered
               defaultHeight=270
-              alwaysUseDefaultHeight=true
               useContentProxy=false
               as |item index|
             }}

--- a/tests/dummy/app/routes/examples/scrollable-body/template.hbs
+++ b/tests/dummy/app/routes/examples/scrollable-body/template.hbs
@@ -2,12 +2,10 @@
     <div class="row">
         <div class="col-sm-7">
           {{!- BEGIN-SNIPPET scrollable-body-example }}
-          {{#vertical-collection model.numbers
-            minHeight=40
-            alwaysRemeasure=true
-            containerSelector="body"
-            indexForFirstItem=20
-            as |item index|
+            {{#vertical-collection model.numbers
+              minHeight=40
+              containerSelector="body"
+              as |item index|
             }}
               {{number-slide isDynamic=true item=item index=index}}
             {{/vertical-collection}}

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -17,6 +17,7 @@ test('The Collection Renders', function(assert) {
   this.render(hbs`
   <div style="height: 500px; width: 500px;">
     {{#vertical-collection ${'items'}
+      staticHeight=true
 
       as |item|}}
       <vertical-item>
@@ -39,6 +40,7 @@ test('The Collection Renders when content is empty', function(assert) {
   this.render(hbs`
   <div style="height: 500px; width: 500px;">
     {{#vertical-collection ${'items'}
+      staticHeight=true
 
       as |item|}}
       <vertical-item>
@@ -62,6 +64,7 @@ test('The Collection Renders with a key path set', function(assert) {
   <div style="height: 500px; width: 500px;">
     {{#vertical-collection ${'items'}
       key="id"
+      staticHeight=true
 
       as |item|}}
       <vertical-item>
@@ -87,6 +90,7 @@ test('The collection renders with containerSelector set', function(assert) {
       {{#vertical-collection ${'items'}
         containerSelector=".scrollable"
         minHeight=20
+        staticHeight=true
         bufferSize=0
 
         as |item i|}}
@@ -114,7 +118,6 @@ test('The collection renders when yielded item has conditional', function(assert
       {{#vertical-collection ${'items'}
         minHeight=10
         containerSelector="body"
-        alwaysRemeasure=true
         as |item|
       }}
         Content

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -21,7 +21,6 @@ test('The collection correctly remeasures items when scrolling down', function(a
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      alwaysRemeasure=true
       minHeight=20
 
       as |item|}}
@@ -58,7 +57,6 @@ test('The collection correctly remeasures items when scrolling up', function(ass
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      alwaysRemeasure=true
       minHeight=20
 
       as |item|}}

--- a/tests/integration/modern-ember-test.js
+++ b/tests/integration/modern-ember-test.js
@@ -14,7 +14,9 @@ if (Ember.VERSION >= '1.13.0') {
     this.set('items', []);
 
     this.render(hbs`
-      {{#vertical-collection ${'items'}}}
+      {{#vertical-collection ${'items'}
+        staticHeight=true
+      }}
         {{else}}
           Foobar
       {{/vertical-collection}}

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -15,7 +15,7 @@ const commonTemplate = hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=20
-      alwaysRemeasure=isDynamic
+      staticHeight=isStatic
 
       as |item i|}}
       <div style="height:20px;">
@@ -25,8 +25,8 @@ const commonTemplate = hbs`
   </div>
 `;
 
-const staticScenario = { isDynamic: false };
-const dynamicScenario = { isDynamic: true };
+const staticScenario = { isStatic: true };
+const dynamicScenario = { isStatic: false };
 
 testScenarios('Collection prepends via array replacement correctly', {
   staticScenario,
@@ -221,7 +221,6 @@ testScenarios('Dynamic collection maintains state if the same list is passed in 
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=20
-      alwaysRemeasure=true
 
       as |item i|}}
       <div style="height:40px;">

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -18,7 +18,6 @@ test('Scroll to last item when actual item sizes are significantly larger than d
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=10
-      alwaysRemeasure=true
 
       as |item i|}}
       <div style="height: 100px;">{{item.text}} {{i}}</div>
@@ -51,6 +50,7 @@ test('Setting renderFromLast on a static collection starts at the bottom of the 
     {{#vertical-collection ${'items'}
       minHeight=100
       renderFromLast=true
+      staticHeight=true
 
       as |item i|}}
       <div style="height: 100px;">{{item.text}} {{i}}</div>
@@ -75,7 +75,6 @@ test('Setting renderFromLast on a dynamic collection starts it at the bottom of 
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=10
-      alwaysRemeasure=true
       renderFromLast=true
 
       as |item i|}}
@@ -101,6 +100,7 @@ test('Setting idForFirstItem on a static collection starts it with the first ite
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=100
+      staticHeight=true
       idForFirstItem=25
       key="@index"
 
@@ -127,7 +127,6 @@ test('Setting idForFirstItem on a dynamic collection starts it with the first it
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=10
-      alwaysRemeasure=true
       idForFirstItem=25
       key="@index"
 
@@ -154,6 +153,7 @@ test('Setting renderFromLast and idForFirstItem on a static collection starts it
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=100
+      staticHeight=true
       renderFromLast=true
       idForFirstItem=25
       key="@index"
@@ -181,7 +181,6 @@ test('Setting renderFromLast and idForFirstItem on a dynamic collection starts i
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=10
-      alwaysRemeasure=true
       renderFromLast=true
       idForFirstItem=25
       key="@index"
@@ -219,6 +218,7 @@ test('Sends the firstVisibleChanged action', function(assert) {
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=20
+      staticHeight=true
       firstVisibleChanged="firstVisibleChanged"
 
       as |item|}}
@@ -251,6 +251,7 @@ test('Sends the lastVisibleChanged action', function(assert) {
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=20
+      staticHeight=true
       lastVisibleChanged="lastVisibleChanged"
 
       as |item|}}
@@ -277,6 +278,7 @@ test('Sends the firstReached action', function(assert) {
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=20
+      staticHeight=true
       firstReached="firstReached"
 
       as |item|}}
@@ -301,6 +303,7 @@ test('Sends the lastReached action', function(assert) {
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=20
+      staticHeight=true
       lastReached="lastReached"
 
       as |item|}}
@@ -328,6 +331,7 @@ test('Sends the firstReached after prepend', function(assert) {
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=20
+      staticHeight=true
       firstReached="firstReached"
 
       as |item index|}}
@@ -353,6 +357,7 @@ test('Sends the lastReached after append', function(assert) {
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       minHeight=20
+      staticHeight=true
       lastReached="lastReached"
 
       as |item index|}}
@@ -373,7 +378,6 @@ test('Collection measures correctly when it\'s scroll parent has scrolled', func
     <div style="height: 400px; width: 100px;" class="scroll-child scrollable">
       {{#vertical-collection ${'items'}
         minHeight=20
-        alwaysRemeasure=true
 
         as |item i|}}
         <div style="height:20px;">
@@ -405,6 +409,7 @@ test('Collection scrolls and measures correctly when parent is a table', functio
         containerSelector=".scrollable"
         tagName="tbody"
         minHeight=37
+        staticHeight=true
 
         as |item i|}}
         <tr>


### PR DESCRIPTION
`alwaysRemeasure` is a vague API name that leaks internal implementation details.
`staticHeight` implies the reverse, and is more clear that the user is opting into
a perf optimization.