### PR TITLE
bugfix(scheduling): Moves all scheduling into the RAF and ensures proper cancelling

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -1,10 +1,7 @@
 import Radar from './index';
 import SkipList from '../skip-list';
-import Ember from 'ember';
 
 import { assert } from 'vertical-collection/-debug/helpers';
-
-const { run } = Ember;
 
 export default class DynamicRadar extends Radar {
   init(...args) {
@@ -72,10 +69,6 @@ export default class DynamicRadar extends Radar {
         this._firstRender = false;
       });
     }
-
-    run.next(() => {
-      this._measure(0, numComponents - 1);
-    });
 
     this._firstItemIndex = firstItemIndex;
     this._lastItemIndex = lastItemIndex;

--- a/addon/-private/data-view/radar/index.js
+++ b/addon/-private/data-view/radar/index.js
@@ -55,7 +55,7 @@ export default class Radar {
     }
 
     this.orderedComponents = null;
-    this.virtualComponents = null;
+    set(this, 'virtualComponents', null);
 
   }
 
@@ -261,7 +261,7 @@ export default class Radar {
 
     if (delta > 0) {
       for (let i = 0; i < delta; i++) {
-        let component = VirtualComponent.create(this.token);
+        let component = VirtualComponent.create();
         set(component, 'content', {});
 
         virtualComponents.pushObject(component);

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -1,4 +1,3 @@
-import Token from 'vertical-collection/-private/scheduler/token';
 import Ember from 'ember';
 
 import { assert } from 'vertical-collection/-debug/helpers';
@@ -9,19 +8,18 @@ const doc = document;
 let VC_IDENTITY = 0;
 
 export default class VirtualComponent {
-  constructor(parentToken) {
+  constructor() {
     this._tenureId = VC_IDENTITY++;
-    this.init(parentToken);
+    this.init();
   }
 
-  init(parentToken) {
+  init() {
     this.id = VC_IDENTITY++;
     this._upperBound = doc.createTextNode('');
     this._lowerBound = doc.createTextNode('');
     this.height = 0;
     this.content = null;
     this.inDOM = false;
-    this.token = new Token(parentToken);
   }
 
   get upperBound() {
@@ -30,10 +28,6 @@ export default class VirtualComponent {
 
   get lowerBound() {
     return this._lowerBound;
-  }
-
-  get parentElement() {
-    return this._upperBound.parentElement;
   }
 
   getBoundingClientRect() {
@@ -52,7 +46,9 @@ export default class VirtualComponent {
   recycle(newContent, newIndex) {
     assert(`You cannot set an item's content to undefined`, newContent);
 
-    set(this, 'index', newIndex);
+    if (this.index !== newIndex) {
+      set(this, 'index', newIndex);
+    }
 
     if (this.content !== newContent) {
       set(this, 'content', newContent);
@@ -60,18 +56,14 @@ export default class VirtualComponent {
   }
 
   destroy() {
-    this.token.cancel();
-    this.range.detach();
-    this.range = null;
-
     this._upperBound = null;
     this._lowerBound = null;
 
     set(this, 'content', null);
   }
 
-  static create(parentToken) {
-    return new VirtualComponent(parentToken);
+  static create() {
+    return new VirtualComponent();
   }
 
   static moveComponents(element, firstComponent, lastComponent, prepend) {

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -295,6 +295,9 @@ const VerticalCollection = Component.extend({
   },
 
   willDestroy() {
+    this._radar.destroy();
+    run.cancel(this._nextSendActions);
+
     removeScrollHandler(this._scrollContainer, this._scrollHandler);
     Container.removeEventListener('resize', this._resizeHandler);
   },
@@ -308,14 +311,8 @@ const VerticalCollection = Component.extend({
     this._radar = new RadarClass();
 
     this._radar.didUpdate = () => {
-      run.next(() => this._sendActions());
+      this._nextSendActions = run.schedule('afterRender', () => this._sendActions());
     };
-  },
-  actions: {
-    heightDidChange(component) {
-      component.hasBeenMeasured = false;
-      this._radar.scheduleUpdate();
-    }
   }
 });
 


### PR DESCRIPTION
Because of the setTimeout bug described in #31, we cannot reliably schedule using setTimeout/ run.next(). There are two places where this happens - 1st in the component itself when it schedules sending actions, and second in the DynamicRadar when it schedules a full measure. The full measure appears to be redundant, as another full measure will be done before any changes occur in the next scroll (per the change in measuring strategy to account for item height changes) and the action sending can be done in the RAF by scheduling on the current runloop (Todo: Add a perf notes/gotchas page in the docs to go over the implications of this design choice).

Also plugs some cancellation bugs that were probably causing the failures in #33.

Closes #31 and #33