### PR TITLE
refactor(reset): Fixes reset and shrinking logic

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -10,6 +10,7 @@ export default class DynamicRadar extends Radar {
     if (!this.initialized) {
       this.skipList = new SkipList(this.items.length, this.minHeight);
       this.initialized = true;
+      this._firstRender = true;
     }
   }
 
@@ -26,7 +27,12 @@ export default class DynamicRadar extends Radar {
     const prevFirstItemIndex = this.firstItemIndex;
     const middleVisibleValue = this.visibleTop + ((this.visibleBottom - this.visibleTop) / 2);
 
-    this._measure(0, numComponents - 1);
+    // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
+    // completely new set of items and won't get an accurate measurement until after they render the
+    // first time.
+    if (prevFirstItemIndex !== null) {
+      this._measure(0, numComponents - 1);
+    }
 
     let {
       totalBefore,
@@ -93,6 +99,8 @@ export default class DynamicRadar extends Radar {
       const currentItem = orderedComponents[i];
       const previousItem = orderedComponents[i - 1];
 
+      // New items that haven't rendered for the first time can exist when a prepend or append
+      // occurs, so we have to verify that each item has been rendered at least once.
       if (!currentItem.inDOM) {
         continue;
       }
@@ -202,7 +210,6 @@ export default class DynamicRadar extends Radar {
 
   resetItems(items) {
     this.skipList = new SkipList(items.length, this.minHeight);
-    this._firstRender = true;
 
     super.resetItems(items);
   }

--- a/addon/-private/data-view/radar/index.js
+++ b/addon/-private/data-view/radar/index.js
@@ -276,6 +276,12 @@ export default class Radar {
           orderedComponents[i].inDOM = true;
         }
       });
+    } else if (delta < 0) {
+      for (let i = delta; i < 0; i++) {
+        const component = orderedComponents.pop();
+        virtualComponents.removeObject(component);
+        component.destroy();
+      }
     }
   }
 
@@ -299,6 +305,8 @@ export default class Radar {
 
   resetItems(items) {
     this.items = items;
+    this.firstItemIndex = null;
+    this.lastItemIndex = null;
 
     this._updateVirtualComponentPool();
     this.scheduleUpdate();

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -69,19 +69,12 @@ export default class VirtualComponent {
   static moveComponents(element, firstComponent, lastComponent, prepend) {
     const rangeToMove = doc.createRange();
 
-    rangeToMove.setStart(firstComponent._upperBound, 0);
-    rangeToMove.setEnd(lastComponent._lowerBound, 0);
+    rangeToMove.setStartBefore(firstComponent._upperBound);
+    rangeToMove.setEndAfter(lastComponent._lowerBound);
 
     const docFragment = rangeToMove.extractContents();
 
     rangeToMove.detach();
-
-    // The first and last nodes in the range do not get extracted, and are instead cloned, so they
-    // have to be reset.
-    //
-    // NOTE: Ember 1.11 - there are cases where docFragment is null (they haven't been rendered yet.)
-    firstComponent._upperBound = docFragment.firstChild || firstComponent._upperBound;
-    lastComponent._lowerBound = docFragment.lastChild || lastComponent._lowerBound;
 
     if (prepend) {
       element.insertBefore(docFragment, element.firstChild);

--- a/addon/components/vertical-collection/template.hbs
+++ b/addon/components/vertical-collection/template.hbs
@@ -1,10 +1,10 @@
 {{#each radar.virtualComponents key="id" as |virtualComponent|}}
-  {{{unbound virtualComponent.upperBound}}}
-    {{yield
-      virtualComponent.content
-      virtualComponent.index
-    }}
-  {{{unbound virtualComponent.lowerBound}}}
+{{unbound virtualComponent.upperBound ~}}
+  {{yield
+    virtualComponent.content
+    virtualComponent.index
+  ~}}
+{{unbound virtualComponent.lowerBound ~}}
 {{/each}}
 
 {{#if shouldYieldToInverse}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -11,6 +11,10 @@ module.exports = function(defaults) {
   var app = new EmberAddon(defaults);
   var checker = new VersionChecker(app);
 
+  app.isDevelopingAddon = () => {
+    return true;
+  };
+
   app.trees.tests = replace('tests', {
     files: ['**/*'],
     pattern: {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
       postTransformPlugins: [StripClassCallCheck]
     };
 
-    if (/production/.test(env) || /test/.test(env)) {
+    if (/production/.test(env) || (/test/.test(env) && !this.isDevelopingAddon())) {
       var strippedImports = {
         'vertical-collection/-debug/helpers': [
           'assert',
@@ -81,7 +81,7 @@ module.exports = {
   treeForAddon: function() {
     var tree = this._super.treeForAddon.apply(this, arguments);
 
-    if (/production/.test(this._env) || /test/.test(this._env)) {
+    if (/production/.test(this._env) || (/test/.test(this._env) && !this.isDevelopingAddon())) {
       tree = new Funnel(tree, { exclude: [ /-debug/ ] });
     }
 
@@ -96,9 +96,5 @@ module.exports = {
     }
 
     return tree;
-  },
-
-  isDevelopingAddon: function() {
-    return true;
   }
 };


### PR DESCRIPTION
Glimmer was messing up due to extra text nodes being inserted, had to remove those.
Also fixed the logic surrounding resetting collections (no state changes or measurements
should occur) and made VC moving a little cleaner.

Fixes #24