### PR TITLE
bugfix(reset): Fixes the case when a collection is emptied

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -61,7 +61,7 @@ export default class DynamicRadar extends Radar {
       totalAfter -= values[i];
     }
 
-    const itemDelta = prevFirstItemIndex ? firstItemIndex - prevFirstItemIndex : 0;
+    const itemDelta = (prevFirstItemIndex !== null) ? firstItemIndex - prevFirstItemIndex : 0;
     const numCulled = Math.abs(itemDelta % numComponents);
 
     if (itemDelta < 0 || this._firstRender) {

--- a/addon/-private/data-view/utils/move-range.js
+++ b/addon/-private/data-view/utils/move-range.js
@@ -1,0 +1,17 @@
+export default function moveRange(destinationElement, firstNode, lastNode, prepend) {
+  let node = firstNode;
+  let nextNode = node.nextSibling;
+  let previousNode = destinationElement.firstChild;
+
+  while (node) {
+    destinationElement.insertBefore(node, prepend ? previousNode.nextSibling : null);
+
+    if (node === lastNode) {
+      break;
+    }
+
+    previousNode = node;
+    node = nextNode;
+    nextNode = node.nextSibling;
+  }
+}

--- a/addon/components/vertical-collection/template.hbs
+++ b/addon/components/vertical-collection/template.hbs
@@ -1,11 +1,8 @@
-{{#each radar.virtualComponents key="id" as |virtualComponent|}}
-{{unbound virtualComponent.upperBound ~}}
-  {{yield
-    virtualComponent.content
-    virtualComponent.index
-  ~}}
-{{unbound virtualComponent.lowerBound ~}}
-{{/each}}
+{{#each radar.virtualComponents key="id" as |virtualComponent| ~}}
+{{{unbound virtualComponent.upperBound}}}
+  {{~yield virtualComponent.content virtualComponent.index ~}}
+{{{unbound virtualComponent.lowerBound}}}
+{{~/each}}
 
 {{#if shouldYieldToInverse}}
   {{yield to="inverse"}}

--- a/tests/dummy/app/helpers/join-strings.js
+++ b/tests/dummy/app/helpers/join-strings.js
@@ -4,11 +4,11 @@ let helper;
 
 if (Ember.Helper) {
   helper = Ember.Helper.helper(function(params) {
-    return params.join();
+    return params.join('');
   });
 } else {
   helper = Ember.Handlebars.makeBoundHelper(function(...params) {
-    return params.join();
+    return params.join('');
   });
 }
 

--- a/tests/helpers/array.js
+++ b/tests/helpers/array.js
@@ -17,3 +17,13 @@ export function append(context, itemsToAppend) {
     context.set('items', items.concat(itemsToAppend));
   }
 }
+
+export function emptyArray(context) {
+  const items = context.get('items');
+
+  if (items.clear) {
+    items.clear();
+  } else {
+    context.set('items', []);
+  }
+}

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -9,7 +9,7 @@ import {
   standardTemplate
 } from 'dummy/tests/helpers/test-scenarios';
 
-import { prepend, append } from 'dummy/tests/helpers/array';
+import { prepend, append, emptyArray } from 'dummy/tests/helpers/array';
 import { paddingBefore, containerHeight } from 'dummy/tests/helpers/measurement';
 
 moduleForComponent('vertical-collection', 'Integration | Mutation Tests', {
@@ -164,7 +164,7 @@ testScenarios(
   scenariosFor(getNumbers(0, 100)),
 
   function(assert) {
-    assert.expect(1);
+    assert.expect(6);
 
     const scrollContainer = this.$('.scrollable');
 
@@ -173,11 +173,69 @@ testScenarios(
 
       return wait();
     }).then(() => {
+      assert.equal(scrollContainer.find('div').length, 31, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '40 40', 'first item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '70 70', 'last item rendered correctly before reset');
+
       this.set('items', getNumbers(0, 10));
 
       return wait();
     }).then(() => {
-      assert.ok(true, 'No errors encountered (Glimmer would have thrown one)');
+      assert.equal(scrollContainer.find('div').length, 10, 'correct number of VCs rendered after reset');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before reset');
+    });
+  }
+);
+
+testScenarios(
+  'Collection can shrink number of items to empty collection',
+  standardTemplate,
+  scenariosFor(getNumbers(0, 100)),
+
+  function(assert) {
+    assert.expect(4);
+
+    const scrollContainer = this.$('.scrollable');
+
+    return wait().then(() => {
+      assert.equal(scrollContainer.find('div').length, 31, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '30 30', 'last item rendered correctly before reset');
+
+      emptyArray(this);
+
+      return wait();
+    }).then(() => {
+      assert.equal(scrollContainer.find('div').length, 0, 'correct number of VCs rendered after reset');
+    });
+  }
+);
+
+testScenarios(
+  'Collection can shrink number of items to empty collection (after scroll has changed)',
+  standardTemplate,
+  scenariosFor(getNumbers(0, 100)),
+
+  function(assert) {
+    assert.expect(4);
+
+    const scrollContainer = this.$('.scrollable');
+
+    return wait().then(() => {
+      scrollContainer.scrollTop(1000);
+
+      return wait();
+    }).then(() => {
+      assert.equal(scrollContainer.find('div').length, 31, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '40 40', 'first item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '70 70', 'last item rendered correctly before reset');
+
+      emptyArray(this);
+
+      return wait();
+    }).then(() => {
+      assert.equal(scrollContainer.find('div').length, 0, 'correct number of VCs rendered after reset');
     });
   }
 );


### PR DESCRIPTION
Turns out Glimmer 1 and 2 track their end nodes slightly differently, so we had to account for that. Glimmer 2 also doesn't seem to completely delete components if you empty an `each`. Caught a couple of small bugs as well.