### PR TITLE
bugfix(render): Add correct items to VCs on initial render

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -25,13 +25,16 @@ export default class DynamicRadar extends Radar {
     const maxIndex = this.totalItems - 1;
     const numComponents = this.orderedComponents.length;
     const prevFirstItemIndex = this.firstItemIndex;
+    const prevLastItemIndex = this.lastItemIndex;
     const middleVisibleValue = this.visibleTop + ((this.visibleBottom - this.visibleTop) / 2);
 
     // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
     // completely new set of items and won't get an accurate measurement until after they render the
     // first time.
     if (prevFirstItemIndex !== null) {
-      this._measure(0, numComponents - 1);
+      // We only need to measure the components that were rendered last time, extra components
+      // haven't rendered yet.
+      this._measure(0, prevLastItemIndex - prevFirstItemIndex);
     }
 
     let {
@@ -99,12 +102,6 @@ export default class DynamicRadar extends Radar {
       const itemIndex = firstItemIndex + i;
       const currentItem = orderedComponents[i];
       const previousItem = orderedComponents[i - 1];
-
-      // New items that haven't rendered for the first time can exist when a prepend or append
-      // occurs, so we have to verify that each item has been rendered at least once.
-      if (!currentItem.inDOM) {
-        continue;
-      }
 
       const {
         top: currentItemTop,

--- a/addon/-private/data-view/radar/index.js
+++ b/addon/-private/data-view/radar/index.js
@@ -263,7 +263,8 @@ export default class Radar {
       minHeight,
       virtualComponents,
       orderedComponents,
-      totalItems
+      totalItems,
+      items
     } = this;
 
     // The total number of components is determined by the minimum number required to span the
@@ -274,17 +275,15 @@ export default class Radar {
     const delta = totalComponents - orderedComponents.length;
 
     if (delta > 0) {
+      const firstItemIndex = orderedComponents.length > 0 ? orderedComponents[orderedComponents.length - 1].index + 1 : 0;
+
       for (let i = 0; i < delta; i++) {
         let component = VirtualComponent.create();
-        set(component, 'content', {});
+        set(component, 'content', objectAt(items, firstItemIndex + i));
 
         virtualComponents.insertAt(virtualComponents.get('length') - 1, component);
         orderedComponents.push(component);
       }
-
-      this.schedule('measure', () => {
-        orderedComponents.slice(totalComponents - delta).forEach((c) => c.inDOM = true);
-      });
     } else if (delta < 0) {
       for (let i = delta; i < 0; i++) {
         let component = orderedComponents.pop();

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -25,7 +25,6 @@ export default class VirtualComponent {
     this._lowerBound = doc.createTextNode('');
     this.height = 0;
     this.content = null;
-    this.inDOM = false;
   }
 
   get element() {


### PR DESCRIPTION
Don't double render, and don't create objects when we don't need to