### PR TITLE
refactor(actions): Makes sure first/lastReached fire only once

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -1,14 +1,27 @@
-import Radar from './radar';
+import { default as Radar, NULL_INDEX } from './radar';
 import SkipList from '../skip-list';
 
 import { assert } from 'vertical-collection/-debug/helpers';
 
 export default class DynamicRadar extends Radar {
+  constructor() {
+    super();
+
+    this._firstItemIndex = NULL_INDEX;
+    this._lastItemIndex = NULL_INDEX;
+
+    this._totalBefore = 0;
+    this._totalAfter = 0;
+
+    this._firstRender = true;
+
+    this.skipList = null;
+  }
+
   init(...args) {
     super.init(...args);
 
     this.skipList = new SkipList(this.totalItems, this.minHeight);
-    this._firstRender = true;
   }
 
   destroy() {
@@ -21,14 +34,14 @@ export default class DynamicRadar extends Radar {
     const { values } = this.skipList;
     const maxIndex = this.totalItems - 1;
     const numComponents = this.orderedComponents.length;
-    const prevFirstItemIndex = this.firstItemIndex;
-    const prevLastItemIndex = this.lastItemIndex;
+    const prevFirstItemIndex = this._prevFirstItemIndex;
+    const prevLastItemIndex = this._prevLastItemIndex;
     const middleVisibleValue = this.visibleTop + ((this.visibleBottom - this.visibleTop) / 2);
 
     // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
     // completely new set of items and won't get an accurate measurement until after they render the
     // first time.
-    if (prevFirstItemIndex !== null) {
+    if (prevFirstItemIndex !== NULL_INDEX) {
       // We only need to measure the components that were rendered last time, extra components
       // haven't rendered yet.
       this._measure(0, prevLastItemIndex - prevFirstItemIndex);
@@ -80,8 +93,6 @@ export default class DynamicRadar extends Radar {
     this._lastItemIndex = lastItemIndex;
     this._totalBefore = totalBefore;
     this._totalAfter = totalAfter;
-
-    return itemDelta;
   }
 
   _measure(firstComponentIndex, lastComponentIndex) {
@@ -154,6 +165,10 @@ export default class DynamicRadar extends Radar {
   }
 
   get firstVisibleIndex() {
+    if (this.firstItemIndex === NULL_INDEX) {
+      return NULL_INDEX;
+    }
+
     const { values } = this.skipList;
 
     let {
@@ -173,6 +188,10 @@ export default class DynamicRadar extends Radar {
   }
 
   get lastVisibleIndex() {
+    if (this.lastItemIndex === NULL_INDEX) {
+      return NULL_INDEX;
+    }
+
     const { total, values } = this.skipList;
 
     let {

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -1,11 +1,14 @@
-import Radar from './radar';
+import { default as Radar, NULL_INDEX } from './radar';
 
 export default class StaticRadar extends Radar {
-  _updateIndexes() {
-    const {
-      _firstItemIndex: prevFirstItemIndex
-    } = this;
+  constructor() {
+    super();
 
+    this._firstItemIndex = NULL_INDEX;
+    this._lastItemIndex = NULL_INDEX;
+  }
+
+  _updateIndexes() {
     const totalIndexes = this.orderedComponents.length;
     const maxIndex = this.totalItems - 1;
 
@@ -27,8 +30,6 @@ export default class StaticRadar extends Radar {
 
     this._firstItemIndex = firstItemIndex;
     this._lastItemIndex = lastItemIndex;
-
-    return firstItemIndex - prevFirstItemIndex;
   }
 
   get total() {
@@ -60,10 +61,14 @@ export default class StaticRadar extends Radar {
   }
 
   get firstVisibleIndex() {
-    return Math.ceil(this.visibleTop / this.minHeight);
+    const firstVisibleIndex = Math.ceil(this.visibleTop / this.minHeight);
+
+    return this.firstItemIndex === NULL_INDEX ? NULL_INDEX : firstVisibleIndex;
   }
 
   get lastVisibleIndex() {
-    return Math.ceil(this.visibleBottom / this.minHeight);
+    const lastVisibleIndex = Math.min(Math.ceil(this.visibleBottom / this.minHeight), this.totalItems - 1);
+
+    return this.firstItemIndex === NULL_INDEX ? NULL_INDEX : lastVisibleIndex;
   }
 }

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -79,9 +79,9 @@ testScenarios(
 
     this.on('firstVisibleChanged', (item, index) => {
       if (count === 0) {
-        assert.equal(index, 0, 'the first last visible changed should be item 0');
+        assert.equal(index, 0, 'the first visible item should be item 0');
       } else {
-        assert.equal(index, 10, 'after scroll the last visible change should be item 10');
+        assert.equal(index, 10, 'after scroll the first visible item should be item 10');
       }
       count++;
       called();
@@ -110,7 +110,7 @@ testScenarios(
       called();
     });
 
-    wait().then(() => this.$('.scrollable').scrollTop(200));
+    return wait().then(() => this.$('.scrollable').scrollTop(200));
   }
 );
 
@@ -146,7 +146,7 @@ testScenarios(
       }
     });
 
-    wait().then(() => this.$('.scrollable').scrollTop(800));
+    return wait().then(() => this.$('.scrollable').scrollTop(800));
   }
 );
 
@@ -178,6 +178,60 @@ testScenarios(
     this.on('lastReached', ({ number }) => {
       append(this, getNumbers(number + 1, 10));
       called();
+    });
+  }
+);
+
+testScenarios(
+  'Does not send the firstReached action twice for the same item',
+  standardTemplate,
+  scenariosFor(getNumbers(0, 50), { firstReached: 'firstReached' }),
+
+  function(assert) {
+    assert.expect(0);
+    const called = assert.async(1);
+
+    this.on('firstReached', () => {
+      called();
+    });
+
+    return wait().then(() => {
+      this.$('.scrollable').scrollTop(800);
+
+      return wait();
+    }).then(() => {
+      this.$('.scrollable').scrollTop(0);
+
+      return wait();
+    });
+  }
+);
+
+testScenarios(
+  'Does not send the lastReached action twice for the same item',
+  standardTemplate,
+  scenariosFor(getNumbers(0, 50), { lastReached: 'lastReached' }),
+
+  function(assert) {
+    assert.expect(0);
+    const called = assert.async(1);
+
+    this.on('lastReached', () => {
+      called();
+    });
+
+    return wait().then(() => {
+      this.$('.scrollable').scrollTop(800);
+
+      return wait();
+    }).then(() => {
+      this.$('.scrollable').scrollTop(0);
+
+      return wait();
+    }).then(() => {
+      this.$('.scrollable').scrollTop(800);
+
+      return wait();
     });
   }
 );


### PR DESCRIPTION
Fixes #52 and #70 

* Adds `firstReached` and `lastReached` key maps that track whether or not we've sent the first/last reached actions for an item. We need separate maps for the case where we have 1 item.
* Moves the handling sending items into the Radar class itself. This is a more natural fit place for the state to live, and it also opens up the door to further refactors in the `vertical-collection` component itself.
* Refactors action sending to schedule independently for each action. This means that if a user only has the `lastReached` action, we won't be using `setTimeout` every time the first/last visible items change, for instance.
* Adds extra properties in constructors to avoid thrashing prototypes