### PR TITLE
Feat/make buffer size static

### DIFF
--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -348,10 +348,10 @@ export default class Radar {
     } = this;
 
     // The total number of components is determined by the minimum number required to span the
-    // container with its buffers. Combined with the above rendering strategy this is fairly
+    // container plus its buffers. Combined with the above rendering strategy this is fairly
     // performant, even if mean item size is above the minimum.
-    const totalHeight = scrollContainerHeight + (scrollContainerHeight * bufferSize * 2);
-    const totalComponents = Math.min(totalItems, Math.ceil(totalHeight / minHeight) + 1);
+    const calculatedComponents = Math.ceil(scrollContainerHeight / minHeight) + 1 + (bufferSize * 2);
+    const totalComponents = Math.min(totalItems, calculatedComponents);
     const delta = totalComponents - orderedComponents.length;
 
     if (delta > 0) {

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -13,7 +13,7 @@ export default class StaticRadar extends Radar {
     const maxIndex = this.totalItems - 1;
 
     const middleVisibleValue = this.visibleTop + ((this.visibleBottom - this.visibleTop)  / 2);
-    const middleItemIndex = Math.ceil(middleVisibleValue / this.minHeight);
+    const middleItemIndex = Math.floor(middleVisibleValue / this.minHeight);
 
     let firstItemIndex = middleItemIndex - Math.floor((totalIndexes - 1) / 2);
     let lastItemIndex = middleItemIndex + Math.ceil((totalIndexes - 1) / 2);

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -62,7 +62,7 @@ const VerticalCollection = Component.extend({
    * how much extra room to keep visible and invisible on
    * either side of the viewport.
    */
-  bufferSize: 1,
+  bufferSize: 0,
 
   // –––––––––––––– Initial Scroll State
   /*

--- a/tests/acceptance/acceptance-tests/record-array-test.js
+++ b/tests/acceptance/acceptance-tests/record-array-test.js
@@ -10,9 +10,9 @@ test('RecordArrays render correctly', function(assert) {
 
   andThen(function() {
     return wait().then(() => {
-      assert.equal(find('number-slide').length, 31, 'correct number of items rendered');
+      assert.equal(find('number-slide').length, 21, 'correct number of items rendered');
       assert.equal(find('number-slide:first').text().replace(/\s/g, ''), '0(0)', 'correct first item rendered');
-      assert.equal(find('number-slide:last').text().replace(/\s/g, ''), '30(30)', 'correct last item rendered');
+      assert.equal(find('number-slide:last').text().replace(/\s/g, ''), '20(20)', 'correct last item rendered');
     });
   });
 });

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -2,6 +2,7 @@
   {{#vertical-collection
     content=model
     minHeight=50
+    bufferSize=5
 
     as |item index|}}
     {{number-slide item=item index=index}}

--- a/tests/dummy/app/routes/examples/dbmon/template.hbs
+++ b/tests/dummy/app/routes/examples/dbmon/template.hbs
@@ -10,8 +10,10 @@
                 containerSelector=".table-wrapper"
                 tagName="tbody"
                 key="id"
+
                 minHeight=37
                 staticHeight=true
+                bufferSize=5
 
                 as |db|
               }}

--- a/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
@@ -7,8 +7,11 @@
           {{#vertical-collection model.numbers
             minHeight=90
             staticHeight=true
+            bufferSize=5
+
             firstReached="loadAbove"
             lastReached="loadBelow"
+
             as |item index|
           }}
             {{number-slide item=item index=index}}

--- a/tests/dummy/app/routes/settings/snippets/defaults.js
+++ b/tests/dummy/app/routes/settings/snippets/defaults.js
@@ -42,16 +42,11 @@ export default
   staticHeight: false,
 
   // The size of the buffer before and after the
-  // collection. Works as a multiplier against the
-  // height of the scrollContainer, e.g. if the
-  // scrollContainer is 200px, and bufferSize is 1,
-  // there will be a 200px buffer before and a 200px
-  // buffer after the scrollContainer. This along with
-  // scrollContainer height determines the number of
-  // components that render at once:
+  // collection. Represents a static number of components
+  // that will be added, such that:
   //
-  // numComponents === (containerHeight + (2 * bufferSize * containerHeight)) / minHeight
-  bufferSize: 1,
+  // numComponents === Math.ceil(containerHeight / minHeight) + (bufferSize * 2) + 1
+  bufferSize: 0,
 
 // actions
 

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -110,7 +110,7 @@ export const standardTemplate = hbs`
     {{#vertical-collection ${'items'}
       minHeight=(either-or minHeight 20)
       staticHeight=staticHeight
-      bufferSize=(either-or bufferSize 1)
+      bufferSize=(either-or bufferSize 5)
 
       renderFromLast=renderFromLast
       idForFirstItem=idForFirstItem

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -54,6 +54,22 @@ testScenarios(
   }
 );
 
+testScenarios(
+  'The collection renders correct number of components with bufferSize set',
+  standardTemplate,
+  scenariosFor(getNumbers(0, 10), { minHeight: 200, bufferSize: 1 }),
+
+  function(assert) {
+    assert.expect(1);
+
+    return wait().then(() => {
+      // Should render 2 components to be able to cover the whole scroll space, and 1
+      // extra buffer component on either side
+      assert.equal(this.$('.scrollable').find('div').length, 4);
+    });
+  }
+);
+
 test('The collection renders with containerSelector set', function(assert) {
   assert.expect(1);
 

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -38,7 +38,7 @@ test('The collection correctly remeasures items when scrolling down', function(a
     assert.equal(paddingBefore(itemContainer), 0, 'itemContainer padding is correct on initial render');
     this.$('.item:first').height(50);
 
-    scrollContainer.scrollTop(251);
+    scrollContainer.scrollTop(51);
 
     return wait();
   }).then(() => {
@@ -71,17 +71,17 @@ test('The collection correctly remeasures items when scrolling up', function(ass
   const itemContainer = this.$('vertical-collection');
 
   return wait().then(() => {
-    assert.equal(paddingAfter(itemContainer), 1380, 'itemContainer padding is correct on initial render');
-    scrollContainer.scrollTop(221);
+    assert.equal(paddingAfter(itemContainer), 1780, 'itemContainer padding is correct on initial render');
+    scrollContainer.scrollTop(21);
 
     return wait();
   }).then(() => {
-    assert.equal(paddingAfter(itemContainer), 1360, 'itemContainer padding is correct after scrolling down');
+    assert.equal(paddingAfter(itemContainer), 1760, 'itemContainer padding is correct after scrolling down');
     this.$('.item:last').height(50);
     scrollContainer.scrollTop(0);
 
     return wait();
   }).then(() => {
-    assert.equal(paddingAfter(itemContainer), 1410, 'itemContainer padding has the height of the modified last element');
+    assert.equal(paddingAfter(itemContainer), 1810, 'itemContainer padding has the height of the modified last element');
   });
 });

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -29,7 +29,7 @@ testScenarios(
 
     return wait().then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before prepend');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '30 30', 'last item rendered correctly before prepnd');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly before prepnd');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct before prepend');
       assert.equal(containerHeight(itemContainer), 2000, 'itemContainer height is correct before prepend');
 
@@ -37,8 +37,8 @@ testScenarios(
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div:first').text().trim(), '-10 10', 'first item rendered correctly after prepend');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '20 40', 'last item rendered correctly after prepend');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '-5 15', 'first item rendered correctly after prepend');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '15 35', 'last item rendered correctly after prepend');
       assert.equal(scrollContainer.scrollTop(), 400, 'scrollTop is correct after prepend');
       assert.equal(containerHeight(itemContainer), 2400, 'itemContainer height is correct after prepend');
     });
@@ -58,7 +58,7 @@ testScenarios(
 
     return wait().then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before append');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '30 30', 'last item rendered correctly before append');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly before append');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct before append');
       assert.equal(containerHeight(itemContainer), 2000, 'itemContainer height is correct after append');
 
@@ -67,7 +67,7 @@ testScenarios(
       return wait();
     }).then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly after append');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '30 30', 'last item rendered correctly after append');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly after append');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct after append');
       assert.equal(containerHeight(itemContainer), 2400, 'itemContainer height is correct after append');
     });
@@ -95,8 +95,8 @@ testScenarios(
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div:first').text().trim(), '-11 9', 'first item rendered correctly after prepend');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '19 39', 'last item rendered correctly after prepend');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '-5 15', 'first item rendered correctly after prepend');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '15 35', 'last item rendered correctly after prepend');
       assert.equal(scrollContainer.scrollTop(), 400, 'scrollTop is correct after prepend');
       assert.equal(containerHeight(itemContainer), 800, 'itemContainer height is correct after prepend');
     });
@@ -106,7 +106,7 @@ testScenarios(
 testScenarios(
   'Collection appends correctly if append would cause more VCs to be shown',
   standardTemplate,
-  scenariosFor(getNumbers(0, 20)),
+  scenariosFor(getNumbers(0, 10)),
 
   function(assert) {
     assert.expect(8);
@@ -116,18 +116,18 @@ testScenarios(
 
     return wait().then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before append');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '19 19', 'last item rendered correctly before append');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before append');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct before append');
-      assert.equal(containerHeight(itemContainer), 400, 'itemContainer height is correct before append');
+      assert.equal(containerHeight(itemContainer), 200, 'itemContainer height is correct before append');
 
-      append(this, getNumbers(20, 20));
+      append(this, getNumbers(10, 20));
 
       return wait();
     }).then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly after append');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '30 30', 'last item rendered correctly after append');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly after append');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct after append');
-      assert.equal(containerHeight(itemContainer), 800, 'itemContainer height is correct after append');
+      assert.equal(containerHeight(itemContainer), 600, 'itemContainer height is correct after append');
     });
   }
 );
@@ -143,9 +143,9 @@ testScenarios(
     const scrollContainer = this.$('.scrollable');
 
     return wait().then(() => {
-      assert.equal(scrollContainer.find('div').length, 31, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div').length, 21, 'correct number of VCs rendered before reset');
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '30 30', 'last item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly before reset');
 
       this.set('items', getNumbers(0, 10));
 
@@ -173,9 +173,9 @@ testScenarios(
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div').length, 31, 'correct number of VCs rendered before reset');
-      assert.equal(scrollContainer.find('div:first').text().trim(), '40 40', 'first item rendered correctly before reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '70 70', 'last item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div').length, 21, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '45 45', 'first item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '65 65', 'last item rendered correctly before reset');
 
       this.set('items', getNumbers(0, 10));
 
@@ -199,9 +199,9 @@ testScenarios(
     const scrollContainer = this.$('.scrollable');
 
     return wait().then(() => {
-      assert.equal(scrollContainer.find('div').length, 31, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div').length, 21, 'correct number of VCs rendered before reset');
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '30 30', 'last item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly before reset');
 
       emptyArray(this);
 
@@ -227,9 +227,9 @@ testScenarios(
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div').length, 31, 'correct number of VCs rendered before reset');
-      assert.equal(scrollContainer.find('div:first').text().trim(), '40 40', 'first item rendered correctly before reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '70 70', 'last item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div').length, 21, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '45 45', 'first item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '65 65', 'last item rendered correctly before reset');
 
       emptyArray(this);
 
@@ -262,7 +262,8 @@ test('Dynamic collection maintains state if the same list is passed in twice', f
   const itemContainer = this.$('vertical-collection');
 
   return wait().then(() => {
-    scrollContainer.scrollTop(541);
+    // Occlude a single item
+    scrollContainer.scrollTop(140);
 
     return wait();
   }).then(() => {

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -160,7 +160,7 @@ testScenarios(
     const called = assert.async(2);
 
     this.on('firstReached', ({ number }) => {
-      prepend(this, getNumbers(number - 10, 10));
+      prepend(this, getNumbers(number - 5, 5));
       called();
     });
   }
@@ -169,14 +169,14 @@ testScenarios(
 testScenarios(
   'Sends the lastReached action after append',
   standardTemplate,
-  standardScenariosFor(getNumbers(0, 20), { lastReached: 'lastReached' }),
+  standardScenariosFor(getNumbers(0, 10), { lastReached: 'lastReached' }),
 
   function(assert) {
     assert.expect(0);
     const called = assert.async(2);
 
     this.on('lastReached', ({ number }) => {
-      append(this, getNumbers(number + 1, 10));
+      append(this, getNumbers(number + 1, 8));
       called();
     });
   }
@@ -268,7 +268,8 @@ testScenarios(
     const scrollContainer = this.$('.scrollable');
 
     return wait().then(() => {
-      scrollContainer.scrollTop(407);
+      // Occlude one item
+      scrollContainer.scrollTop(38);
 
       return wait();
     }).then(() => {


### PR DESCRIPTION
Makes `bufferSize` a static number, with a default of 5 (10 extra components in general). Open to bikeshedding on the default value, it may make more sense to set it to 0 and let users decide what makes sense for them.

Also updates the tests, and makes sure that `StaticRadar` has the same result as `DynamicRadar` for given offset (if heights/settings are identical).