### PR TITLE
bugfix(skiplist): Use Float32Arrays in the SkipList

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,9 +13,7 @@ module.exports = {
   },
   globals: {
     ArrayBuffer: true,
-    Uint32Array: true,
-    Uint16Array: true,
-    Uint8Array: true
+    Float32Array: true
   },
   rules: {
     'quotes': ['error', 'single', {  "allowTemplateLiterals": true, "avoidEscape": true }],

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -119,9 +119,9 @@ export default class DynamicRadar extends Radar {
       let margin;
 
       if (previousItem) {
-        margin = Math.round(currentItemTop - previousItem.getBoundingClientRect().bottom);
+        margin = currentItemTop - previousItem.getBoundingClientRect().bottom;
       } else {
-        margin = Math.round(currentItemTop - itemContainer.getBoundingClientRect().top - totalBefore);
+        margin = currentItemTop - itemContainer.getBoundingClientRect().top - totalBefore;
       }
 
       assert(`item height + margin must always be above the minimum value ${this.minHeight}px. The item at index ${itemIndex} measured: ${currentItemHeight + margin}`, currentItemHeight + margin >= this.minHeight);

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -15,7 +15,7 @@ import { assert } from 'vertical-collection/-debug/helpers';
  *
  * This data structure acts somewhat like a Binary Search Tree. Given a list of size n, the
  * retreival time for the index is O(log n) and the update time should any values change is
- * O(log n). The space complexity is O(n log n) in bytes (using Uint16/32Arrays helps a lot
+ * O(log n). The space complexity is O(n log n) in bytes (using Float32Arrays helps a lot
  * here), and the initialization time is O(n log n).
  *
  * It works by constructing layer arrays, each of which is setup such that
@@ -26,7 +26,7 @@ import { assert } from 'vertical-collection/-debug/helpers';
 
 export default class SkipList {
   constructor(length, defaultValue) {
-    const values = new Uint16Array(new ArrayBuffer(length * 2));
+    const values = new Float32Array(new ArrayBuffer(length * 4));
 
     values.fill(defaultValue);
 
@@ -38,7 +38,7 @@ export default class SkipList {
 
   _initializeLayers(values, defaultValue) {
     const layers = [values];
-    let i, length, buffer, layer, prevLayer, left, right;
+    let i, length, layer, prevLayer, left, right;
 
     prevLayer = layer = values;
     length = values.length;
@@ -46,8 +46,7 @@ export default class SkipList {
     while (length > 2) {
       length = Math.ceil(length / 2);
 
-      buffer = new ArrayBuffer(length * 4);
-      layer = new Uint32Array(buffer);
+      layer = new Float32Array(new ArrayBuffer(length * 4));
 
       if (defaultValue) {
         // If given a default value we assume that we can fill each
@@ -166,7 +165,7 @@ export default class SkipList {
 
     const newLength = numPrepended + oldLength;
 
-    const newValues = new Uint16Array(new ArrayBuffer(newLength * 2));
+    const newValues = new Float32Array(new ArrayBuffer(newLength * 4));
 
     newValues.set(oldValues, numPrepended);
     newValues.fill(defaultValue, 0, numPrepended);
@@ -184,7 +183,7 @@ export default class SkipList {
 
     const newLength = numAppended + oldLength;
 
-    const newValues = new Uint16Array(new ArrayBuffer(newLength * 2));
+    const newValues = new Float32Array(new ArrayBuffer(newLength * 4));
 
     newValues.set(oldValues);
     newValues.fill(defaultValue, oldLength);

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -85,3 +85,34 @@ test('The collection correctly remeasures items when scrolling up', function(ass
     assert.equal(paddingAfter(itemContainer), 1810, 'itemContainer padding has the height of the modified last element');
   });
 });
+
+test('Can scroll correctly in dynamic list of items that has non-integer heights', function(assert) {
+  assert.expect(2);
+
+  this.set('items', getNumbers(0, 21));
+
+  this.render(hbs`
+  <div style="height: 200px; width: 100px;" class="scrollable">
+    {{#vertical-collection ${'items'}
+      minHeight=20
+
+      as |item i|}}
+      <div style="height: 33.333px;">{{item.number}} {{i}}</div>
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  const scrollable = this.$('.scrollable');
+  const itemContainer = this.$('vertical-collection');
+
+  return wait()
+    .then(() => scrollable.scrollTop(scrollable.get(0).scrollHeight))
+    .then(wait)
+    .then(() => {
+      // Floats aren't perfect, neither is browser rendering/measuring, but any subpixel errors
+      // should be amplified to the point where they are very noticeable at this point, so rounding
+      // should provide some safety.
+      assert.equal(Math.round(paddingBefore(itemContainer)), 333, 'Occluded content has the correct height before');
+      assert.equal(paddingAfter(itemContainer), 0, 'Occluded content has the correct height after');
+    });
+});


### PR DESCRIPTION
Uses Float32Arrays to get sub-pixel accuracy from measurements. Fixes #76