### PR TITLE
Fix dynamic start with offset

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -83,7 +83,7 @@ export default class DynamicRadar extends Radar {
     const itemDelta = (prevFirstItemIndex !== null) ? firstItemIndex - prevFirstItemIndex : 0;
     const numCulled = Math.abs(itemDelta % numComponents);
 
-    if (itemDelta < 0 || this._firstRender) {
+    if (itemDelta < 0 || this._firstRender === true) {
       // schedule a measurement for items that could affect scrollTop
       this.schedule('measure', () => {
         const staticVisibleIndex = this.renderFromLast ? this.lastVisibleIndex + 1 : this.firstVisibleIndex;
@@ -124,6 +124,7 @@ export default class DynamicRadar extends Radar {
 
       let margin;
 
+      // TODO add explicit test
       if (previousItem) {
         margin = currentItemTop - previousItem.getBoundingClientRect().bottom;
       } else {
@@ -231,7 +232,7 @@ export default class DynamicRadar extends Radar {
   updateItems(items, isReset) {
     super.updateItems(items, isReset);
 
-    if (isReset) {
+    if (isReset === true) {
       this.skipList = new SkipList(this.totalItems, this.minHeight);
     }
   }

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -36,7 +36,7 @@ export default class DynamicRadar extends Radar {
     const numComponents = this.orderedComponents.length;
     const prevFirstItemIndex = this._prevFirstItemIndex;
     const prevLastItemIndex = this._prevLastItemIndex;
-    const middleVisibleValue = this.visibleTop + ((this.visibleBottom - this.visibleTop) / 2);
+    const middleVisibleValue = this.visibleTop + (this.scrollContainerHeight / 2);
 
     // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
     // completely new set of items and won't get an accurate measurement until after they render the

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -36,7 +36,7 @@ export default class DynamicRadar extends Radar {
     const numComponents = this.orderedComponents.length;
     const prevFirstItemIndex = this._prevFirstItemIndex;
     const prevLastItemIndex = this._prevLastItemIndex;
-    const middleVisibleValue = this.visibleTop + (this.scrollContainerHeight / 2);
+    const middleVisibleValue = this.scrollTop + (this.scrollContainerHeight / 2);
 
     // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
     // completely new set of items and won't get an accurate measurement until after they render the

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -18,7 +18,7 @@ export default class DynamicRadar extends Radar {
     this.skipList = null;
 
     stripInProduction(() => {
-      Object.freeze(this);
+      Object.preventExtensions(this);
     });
   }
 

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -36,7 +36,13 @@ export default class DynamicRadar extends Radar {
     const numComponents = this.orderedComponents.length;
     const prevFirstItemIndex = this._prevFirstItemIndex;
     const prevLastItemIndex = this._prevLastItemIndex;
-    const middleVisibleValue = this.scrollTop + (this.scrollContainerHeight / 2);
+    let top = this.visibleTop;
+
+    if (top < 0) {
+      top = 0;
+    }
+
+    const middleVisibleValue = top + (this.scrollContainerHeight / 2);
 
     // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
     // completely new set of items and won't get an accurate measurement until after they render the

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -1,7 +1,7 @@
 import { default as Radar, NULL_INDEX } from './radar';
 import SkipList from '../skip-list';
 
-import { assert } from 'vertical-collection/-debug/helpers';
+import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
 
 export default class DynamicRadar extends Radar {
   constructor() {
@@ -16,6 +16,10 @@ export default class DynamicRadar extends Radar {
     this._firstRender = true;
 
     this.skipList = null;
+
+    stripInProduction(() => {
+      Object.freeze(this);
+    });
   }
 
   init(...args) {

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -388,7 +388,7 @@ export default class Radar {
   updateItems(items, isReset = false) {
     this.items = items;
 
-    if (isReset === true) {init
+    if (isReset === true) {
 
       this._firstReached = false;
       this._lastReached = false;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -20,6 +20,7 @@ export const NULL_INDEX = -2;
 export default class Radar {
   constructor() {
     this.token = new Token();
+    this.items = null;
 
     this._scrollTop = 0;
     this._prependOffset = 0;
@@ -38,6 +39,7 @@ export default class Radar {
     this._prevLastItemIndex = NULL_INDEX;
     this._prevFirstVisibleIndex = NULL_INDEX;
     this._prevLastVisibleIndex = NULL_INDEX;
+    this.scrollContainerHeight = 0;
 
     this._firstReached = false;
     this._lastReached = false;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -57,6 +57,11 @@ export default class Radar {
     this.itemContainer = itemContainer;
     this.scrollContainer = scrollContainer;
 
+    this._prevFirstItemIndex = NULL_INDEX;
+    this._prevLastItemIndex = NULL_INDEX;
+    this._prevFirstVisibleIndex = NULL_INDEX;
+    this._prevLastVisibleIndex = NULL_INDEX;
+
     this.minHeight = minHeight;
     this.bufferSize = bufferSize;
     this.renderFromLast = renderFromLast;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -39,10 +39,8 @@ export default class Radar {
     this._prevLastItemIndex = NULL_INDEX;
     this._prevFirstVisibleIndex = NULL_INDEX;
     this._prevLastVisibleIndex = NULL_INDEX;
-    this.firstItemIndex = NULL_INDEX;
-    this.lastItemIndex = NULL_INDEX;
-    this.firstVisibleIndex = NULL_INDEX;
-    this.lastVisibleIndex = NULL_INDEX;
+    this._firstItemIndex = NULL_INDEX;
+    this._lastItemIndex = NULL_INDEX;
     this.scrollContainerHeight = 0;
 
     this._firstReached = false;
@@ -65,10 +63,8 @@ export default class Radar {
     this._prevLastItemIndex = NULL_INDEX;
     this._prevFirstVisibleIndex = NULL_INDEX;
     this._prevLastVisibleIndex = NULL_INDEX;
-    this.firstItemIndex = NULL_INDEX;
-    this.lastItemIndex = NULL_INDEX;
-    this.firstVisibleIndex = NULL_INDEX;
-    this.lastVisibleIndex = NULL_INDEX;
+    this._firstItemIndex = NULL_INDEX;
+    this._lastItemIndex = NULL_INDEX;
 
     this.minHeight = minHeight;
     this.bufferSize = bufferSize;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -75,7 +75,6 @@ export default class Radar {
 
     this.orderedComponents = null;
     set(this, 'virtualComponents', null);
-
   }
 
   schedule(queueName, job) {

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -39,6 +39,10 @@ export default class Radar {
     this._prevLastItemIndex = NULL_INDEX;
     this._prevFirstVisibleIndex = NULL_INDEX;
     this._prevLastVisibleIndex = NULL_INDEX;
+    this.firstItemIndex = NULL_INDEX;
+    this.lastItemIndex = NULL_INDEX;
+    this.firstVisibleIndex = NULL_INDEX;
+    this.lastVisibleIndex = NULL_INDEX;
     this.scrollContainerHeight = 0;
 
     this._firstReached = false;
@@ -61,6 +65,10 @@ export default class Radar {
     this._prevLastItemIndex = NULL_INDEX;
     this._prevFirstVisibleIndex = NULL_INDEX;
     this._prevLastVisibleIndex = NULL_INDEX;
+    this.firstItemIndex = NULL_INDEX;
+    this.lastItemIndex = NULL_INDEX;
+    this.firstVisibleIndex = NULL_INDEX;
+    this.lastVisibleIndex = NULL_INDEX;
 
     this.minHeight = minHeight;
     this.bufferSize = bufferSize;
@@ -384,9 +392,7 @@ export default class Radar {
   updateItems(items, isReset = false) {
     this.items = items;
 
-    if (isReset === true) {
-      this.firstItemIndex = NULL_INDEX;
-      this.lastItemIndex = NULL_INDEX;
+    if (isReset === true) {init
 
       this._firstReached = false;
       this._lastReached = false;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -389,6 +389,8 @@ export default class Radar {
     this.items = items;
 
     if (isReset === true) {
+      this.firstItemIndex = NULL_INDEX;
+      this.lastItemIndex = NULL_INDEX;
 
       this._firstReached = false;
       this._lastReached = false;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -92,7 +92,7 @@ export default class Radar {
    * @private
    */
   scheduleUpdate() {
-    if (this._nextUpdate) {
+    if (this._nextUpdate !== null) {
       return;
     }
 
@@ -377,7 +377,7 @@ export default class Radar {
   updateItems(items, isReset = false) {
     this.items = items;
 
-    if (isReset) {
+    if (isReset === true) {
       this.firstItemIndex = NULL_INDEX;
       this.lastItemIndex = NULL_INDEX;
 

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -27,6 +27,7 @@ export default class Radar {
 
     this._itemContainer = null;
     this._scrollContainer = null;
+    this._nextUpdate = null;
 
     this.minHeight = 0;
     this.bufferSize = 0;

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -1,4 +1,5 @@
 import { default as Radar, NULL_INDEX } from './radar';
+import { stripInProduction } from 'vertical-collection/-debug/helpers';
 
 export default class StaticRadar extends Radar {
   constructor() {
@@ -6,6 +7,10 @@ export default class StaticRadar extends Radar {
 
     this._firstItemIndex = NULL_INDEX;
     this._lastItemIndex = NULL_INDEX;
+
+    stripInProduction(() => {
+      Object.freeze(this);
+    });
   }
 
   _updateIndexes() {

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -9,7 +9,7 @@ export default class StaticRadar extends Radar {
     this._lastItemIndex = NULL_INDEX;
 
     stripInProduction(() => {
-      Object.freeze(this);
+      Object.preventExtensions(this);
     });
   }
 

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -48,6 +48,7 @@ export default class SkipList {
 
       layer = new Float32Array(new ArrayBuffer(length * 4));
 
+      // TODO add explicit test
       if (defaultValue) {
         // If given a default value we assume that we can fill each
         // layer of the skip list with the previous layer's value * 2.

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -1,4 +1,4 @@
-import { assert } from 'vertical-collection/-debug/helpers';
+import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
 
 /*
  * `SkipList` is a data structure designed with two main uses in mind:
@@ -34,6 +34,10 @@ export default class SkipList {
     this.defaultValue = defaultValue;
 
     this._initializeLayers(values, defaultValue);
+
+    stripInProduction(() => {
+      Object.freeze(this);
+    });
   }
 
   _initializeLayers(values, defaultValue) {

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -36,7 +36,7 @@ export default class SkipList {
     this._initializeLayers(values, defaultValue);
 
     stripInProduction(() => {
-      Object.freeze(this);
+      Object.preventExtensions(this);
     });
   }
 

--- a/addon/-private/data-view/utils/scroll-handler.js
+++ b/addon/-private/data-view/utils/scroll-handler.js
@@ -37,6 +37,7 @@ export class ScrollHandler {
         left: element.scrollLeft,
         handlers
       };
+      // TODO add explicit test
       if (SUPPORTS_PASSIVE) {
         cache.passiveHandler = function() {
           ScrollHandler.triggerElementHandlers(element, cache);
@@ -50,8 +51,11 @@ export class ScrollHandler {
       handlers.push(handler);
     }
 
+    // TODO add explicit test
     if (this.isUsingPassive && handlers.length === 1) {
       element.addEventListener('scroll', cache.passiveHandler, { capture: true, passive: true });
+
+    // TODO add explicit test
     } else if (!this.isPolling) {
       this.poll();
     }
@@ -60,7 +64,7 @@ export class ScrollHandler {
   removeScrollHandler(element, handler) {
     let index = this.elements.indexOf(element);
     let elementCache = this.handlers[index];
-
+    // TODO add explicit test
     if (elementCache && elementCache.handlers) {
       let index = elementCache.handlers.indexOf(handler);
 
@@ -71,6 +75,7 @@ export class ScrollHandler {
       elementCache.handlers.splice(index, 1);
 
       // cleanup element entirely if needed
+      // TODO add explicit test
       if (!elementCache.handlers.length) {
         index = this.elements.indexOf(element);
         this.handlers.splice(index, 1);
@@ -83,6 +88,7 @@ export class ScrollHandler {
           this.isPolling = false;
         }
 
+        // TODO add explicit test
         if (this.isUsingPassive) {
           element.removeEventListener('scroll', elementCache.passiveHandler, { capture: true, passive: true });
         }
@@ -104,6 +110,7 @@ export class ScrollHandler {
 
     let event = { top: cachedTop, left: cachedLeft };
 
+    // TODO add explicit test
     if (topChanged || leftChanged) {
       run.begin();
       for (let j = 0; j < meta.handlers.length; j++) {
@@ -117,6 +124,7 @@ export class ScrollHandler {
     this.isPolling = true;
 
     scheduler.schedule('sync', () => {
+      // TODO add explicit test
       if (!this.isPolling) {
         return;
       }
@@ -129,6 +137,7 @@ export class ScrollHandler {
       }
 
       this.isPolling = this.length > 0;
+      // TODO add explicit test
       if (this.isPolling) {
         this.poll();
       }

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -11,48 +11,36 @@ export default class VirtualComponent {
   constructor(element) {
     this.id = VC_IDENTITY++;
 
-    this._element = element;
+    this.element = element;
 
-    this._upperBound = document.createTextNode('');
-    this._lowerBound = document.createTextNode('');
+    this.upperBound = document.createTextNode('');
+    this.lowerBound = document.createTextNode('');
+
+    this.content = null;
+    this.index = 0;
 
     // In older versions of Ember, binding anything on an object in the template
     // adds observers which creates __ember_meta__
     this.__ember_meta__ = null; // eslint-disable-line camelcase
-
-    this.content = null;
-    this.index = 0;
 
     stripInProduction(() => {
       Object.preventExtensions(this);
     });
   }
 
-  get element() {
-    return this._element;
-  }
-
-  get upperBound() {
-    return this._upperBound;
-  }
-
   get realUpperBound() {
-    return IS_GLIMMER_2 ? this._upperBound : this._upperBound.previousSibling;
-  }
-
-  get lowerBound() {
-    return this._lowerBound;
+    return IS_GLIMMER_2 ? this.upperBound : this.upperBound.previousSibling;
   }
 
   get realLowerBound() {
-    return IS_GLIMMER_2 ? this._lowerBound : this._lowerBound.nextSibling;
+    return IS_GLIMMER_2 ? this.lowerBound : this.lowerBound.nextSibling;
   }
 
   getBoundingClientRect() {
     const range = document.createRange();
 
-    range.setStartBefore(this._upperBound);
-    range.setEndAfter(this._lowerBound);
+    range.setStartBefore(this.upperBound);
+    range.setEndAfter(this.lowerBound);
 
     const rect = range.getBoundingClientRect();
 
@@ -74,9 +62,10 @@ export default class VirtualComponent {
   }
 
   destroy() {
-    this._element = null;
-    this._upperBound = null;
-    this._lowerBound = null;
+    set(this, 'element', null);
+    set(this, 'upperBound', null);
+    set(this, 'lowerBound', null);
     set(this, 'content', null);
+    set(this, 'index', null);
   }
 }

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -24,7 +24,7 @@ export default class VirtualComponent {
     this.__ember_meta__ = null; // eslint-disable-line camelcase
 
     stripInProduction(() => {
-      Object.seal(this);
+      Object.preventExtensions(this);
     });
   }
 

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { IS_GLIMMER_2 } from '../ember-internals/compatibility';
 
-import { assert } from 'vertical-collection/-debug/helpers';
+import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
 
 const { set } = Ember;
 
@@ -17,6 +17,10 @@ export default class VirtualComponent {
     this._lowerBound = document.createTextNode('');
 
     this.content = null;
+
+    stripInProduction(() => {
+      Object.freeze(this);
+    });
   }
 
   get element() {

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -24,7 +24,7 @@ export default class VirtualComponent {
     this.__ember_meta__ = null; // eslint-disable-line camelcase
 
     stripInProduction(() => {
-      Object.preventExtensions(this);
+      Object.seal(this);
     });
   }
 

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -17,9 +17,10 @@ export default class VirtualComponent {
     this._lowerBound = document.createTextNode('');
 
     this.content = null;
+    this.index = 0;
 
     stripInProduction(() => {
-      Object.freeze(this);
+      Object.preventExtensions(this);
     });
   }
 

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -16,6 +16,10 @@ export default class VirtualComponent {
     this._upperBound = document.createTextNode('');
     this._lowerBound = document.createTextNode('');
 
+    // In older versions of Ember, binding anything on an object in the template
+    // adds observers which creates __ember_meta__
+    this.__ember_meta__ = null; // eslint-disable-line camelcase
+
     this.content = null;
     this.index = 0;
 

--- a/addon/-private/ember-internals/utils/key-for-item.js
+++ b/addon/-private/ember-internals/utils/key-for-item.js
@@ -21,6 +21,7 @@ export default function keyForItem(item, keyPath, index) {
       key = identity(item);
       break;
     default:
+      // TODO add explicit test
       if (keyPath) {
         key = get(item, keyPath);
       } else {

--- a/addon/-private/scheduler/index.js
+++ b/addon/-private/scheduler/index.js
@@ -49,6 +49,7 @@ export class Scheduler {
   }
 
   forget(token) {
+    // TODO add explicit test
     if (token) {
       token.cancel();
     }
@@ -69,6 +70,7 @@ export class Scheduler {
     let hasDomWork = this.sync.length > 0 || this.layout.length > 0;
     this.jobs = 0;
 
+    // TODO add explicit test
     if (hasDomWork) {
       run.begin();
       if (this.sync.length > 0) {

--- a/addon/-private/scheduler/index.js
+++ b/addon/-private/scheduler/index.js
@@ -11,7 +11,7 @@ export class Token {
     this._cancelled = false;
 
     stripInProduction(() => {
-      Object.preventExtensions(this);
+      Object.seal(this);
     });
   }
 
@@ -41,6 +41,10 @@ export class Scheduler {
     this.jobs = 0;
     this._nextFlush = null;
     this.ticks = 0;
+
+    stripInProduction(() => {
+      Object.seal(this);
+    });
   }
 
   schedule(queueName, cb, parent) {

--- a/addon/-private/scheduler/index.js
+++ b/addon/-private/scheduler/index.js
@@ -11,7 +11,7 @@ export class Token {
     this._cancelled = false;
 
     stripInProduction(() => {
-      Object.freeze(this);
+      Object.preventExtensions(this);
     });
   }
 

--- a/addon/-private/scheduler/index.js
+++ b/addon/-private/scheduler/index.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { stripInProduction } from 'vertical-collection/-debug/helpers';
 
 const {
   run
@@ -8,6 +9,10 @@ export class Token {
   constructor(parent) {
     this._parent = parent;
     this._cancelled = false;
+
+    stripInProduction(() => {
+      Object.freeze(this);
+    });
   }
 
   get cancelled() {

--- a/addon/-private/utils/element/apply-dimensions.js
+++ b/addon/-private/utils/element/apply-dimensions.js
@@ -1,5 +1,7 @@
+// TODO is this util used
 export default function applyDimensions(element, dimensions) {
   for (const i in dimensions.style) {
+    // TODO add explicit test
     if (dimensions.style.hasOwnProperty(i)) {
       element.style[i] = i === 'boxSizing' ? dimensions.style[i] : `${dimensions.style[i]}px`;
     }

--- a/addon/-private/utils/element/closest.js
+++ b/addon/-private/utils/element/closest.js
@@ -14,6 +14,7 @@ export default function closest(el, selector) {
     setElementMatchFn(el);
   }
   while (el) {
+    // TODO add explicit test
     if (el[ELEMENT_MATCH_FN](selector)) {
       return el;
     }

--- a/addon/-private/utils/element/get-height.js
+++ b/addon/-private/utils/element/get-height.js
@@ -14,6 +14,8 @@ export default function getHeight(dims, withMargins) {
       height = dims.height;
       break;
   }
+
+  // TODO add explicit test
   if (withMargins) {
     height += dims.marginTop + dims.marginBottom;
   }

--- a/addon/-private/utils/element/get-width.js
+++ b/addon/-private/utils/element/get-width.js
@@ -14,6 +14,8 @@ export default function getWidth(dims, withMargins) {
       width = dims.width;
       break;
   }
+
+  // TODO add explicit test
   if (withMargins) {
     width += dims.marginLeft + dims.marginRight;
   }

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -15,7 +15,7 @@ import {
   removeScrollHandler
 } from '../../-private';
 
-import { assert } from 'vertical-collection/-debug/helpers';
+import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
 
 const {
   computed,
@@ -291,6 +291,10 @@ const VerticalCollection = Component.extend({
         }
       };
     }
+
+    stripInProduction(() => {
+      Object.freeze(this);
+    });
   }
 });
 

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -39,6 +39,7 @@ const VerticalCollection = Component.extend({
   items: null,
 
   // deprecated, only for use in Ember 1.11
+  // TODO remove this
   content: null,
 
   // –––––––––––––– Optional Settings
@@ -84,7 +85,7 @@ const VerticalCollection = Component.extend({
   renderFromLast: false,
 
   // –––––––––––––– @private
-
+  // TODO remove this
   _items: computed.or('items', 'content'),
 
   _calculateMinHeight() {
@@ -127,8 +128,10 @@ const VerticalCollection = Component.extend({
       this._prevItemsLength = this._prevFirstKey = this._prevLastKey = null;
     }
 
+    // TODO add explicit test
     if (isPrepend(lenDiff, items, key, _prevFirstKey, _prevLastKey)) {
       _radar.prepend(items, lenDiff);
+      // TODO add explicit test
     } else if (isAppend(lenDiff, items, key, _prevFirstKey, _prevLastKey)) {
       _radar.append(items, lenDiff);
     } else {
@@ -184,7 +187,7 @@ const VerticalCollection = Component.extend({
    * @private
    */
   _initializeRadar() {
-    const minHeight = this.get('_minHeight');
+    const minHeight = this._minHeight;
     const bufferSize = this.get('bufferSize');
     const renderFromLast = this.get('renderFromLast');
     const keyProperty = this.get('key');
@@ -202,25 +205,29 @@ const VerticalCollection = Component.extend({
     const idForFirstItem = this.get('idForFirstItem');
     const key = this.get('key');
 
-    const minHeight = this.get('_minHeight');
+    const minHeight = this._minHeight;
     const items = this.get('_items');
     const totalItems = get(items, 'length');
 
     let visibleTop = 0;
 
+    // TODO add explicit test
     if (idForFirstItem) {
       for (let i = 0; i < totalItems - 1; i++) {
+        // TODO strict equality
         if (keyForItem(objectAt(items, i), key, i) == idForFirstItem) {
           visibleTop = i * minHeight;
           break;
         }
       }
 
+      // TODO add explicit test
     } else if (renderFromLast) {
       // If no id was set and `renderFromLast` is true, start from the bottom
       visibleTop = (totalItems - 1) * minHeight;
     }
 
+    // TODO add explicit test
     if (renderFromLast) {
       visibleTop -= (this._radar.scrollContainerHeight - minHeight);
     }
@@ -238,7 +245,7 @@ const VerticalCollection = Component.extend({
     this._lastEarthquake = this._radar.scrollTop;
 
     this._scrollHandler = ({ top }) => {
-      if (Math.abs(this._lastEarthquake - top) > this.get('_minHeight') / 2) {
+      if (Math.abs(this._lastEarthquake - top) > this._minHeight / 2) {
         this._radar.scheduleUpdate();
         this._lastEarthquake = top;
       }

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -139,7 +139,7 @@ const VerticalCollection = Component.extend({
         this._nextSendActions = null;
 
         run(() => {
-          const items = this.get('_items');
+          const items = this.get('items');
           const keyPath = this.get('key');
 
           this._scheduledActions.forEach(([action, index]) => {

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -15,7 +15,7 @@ import {
   removeScrollHandler
 } from '../../-private';
 
-import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
+import { assert } from 'vertical-collection/-debug/helpers';
 
 const {
   computed,

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -229,6 +229,8 @@ const VerticalCollection = Component.extend({
     // on initialization, so we set this min-height property to radar's total
     this.element.style.minHeight = `${minHeight * totalItems}px`;
 
+    visibleTop -= this._radar.scrollTopOffset;
+
     this._radar.visibleTop = visibleTop;
   },
 

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -296,10 +296,6 @@ const VerticalCollection = Component.extend({
         }
       };
     }
-
-    stripInProduction(() => {
-      Object.seal(this);
-    });
   }
 });
 

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -15,7 +15,7 @@ import {
   removeScrollHandler
 } from '../../-private';
 
-import { assert } from 'vertical-collection/-debug/helpers';
+import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
 
 const {
   computed,
@@ -95,7 +95,7 @@ const VerticalCollection = Component.extend({
   isEmpty: computed.empty('items'),
   shouldYieldToInverse: computed.and('isEmpty', 'supportsInverse'),
 
-  radar: computed('items.[]', function() {
+  virtualComponents: computed('items.[]', function() {
     const {
       _radar,
       _prevItemsLength,
@@ -128,7 +128,7 @@ const VerticalCollection = Component.extend({
       _radar.updateItems(items, isReset);
     }
 
-    return this._radar;
+    return this._radar.virtualComponents;
   }),
 
   _scheduleSendAction(action, index) {

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -92,15 +92,12 @@ const VerticalCollection = Component.extend({
     }
   },
 
-  supportsInverse: SUPPORTS_INVERSE_BLOCK,
-
   isEmpty: computed.empty('items'),
   shouldYieldToInverse: computed.and('isEmpty', 'supportsInverse'),
 
   radar: computed('items.[]', function() {
     const {
       _radar,
-
       _prevItemsLength,
       _prevFirstKey,
       _prevLastKey
@@ -110,14 +107,14 @@ const VerticalCollection = Component.extend({
     const itemsLength = get(items, 'length');
 
     const key = this.get('key');
-    const lenDiff = itemsLength - (_prevItemsLength || 0);
+    const lenDiff = itemsLength - _prevItemsLength;
 
     if (itemsLength > 0) {
       this._prevItemsLength = itemsLength;
       this._prevFirstKey = keyForItem(objectAt(items, 0), key, 0);
       this._prevLastKey = keyForItem(objectAt(items, itemsLength - 1), key, itemsLength - 1);
     } else {
-      this._prevItemsLength = this._prevFirstKey = this._prevLastKey = null;
+      this._prevItemsLength = this._prevFirstKey = this._prevLastKey = 0;
     }
 
     // TODO add explicit test
@@ -265,6 +262,14 @@ const VerticalCollection = Component.extend({
     this._minHeight = this._calculateMinHeight();
     const RadarClass = this.get('staticHeight') ? StaticRadar : DynamicRadar;
 
+    this.supportsInverse = SUPPORTS_INVERSE_BLOCK;
+    this._prevItemsLength = 0;
+    this._prevFirstKey = null;
+    this._prevLastKey = null;
+    this._lastEarthquake = null;
+    this._scrollContainer = null;
+    this._scrollHandler = null;
+    this._resizeHandler = null;
     this._radar = new RadarClass();
 
     this._hasAction = null;
@@ -293,7 +298,7 @@ const VerticalCollection = Component.extend({
     }
 
     stripInProduction(() => {
-      Object.freeze(this);
+      Object.seal(this);
     });
   }
 });

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -38,10 +38,6 @@ const VerticalCollection = Component.extend({
   // usable via {{#vertical-collection <items-array>}}
   items: null,
 
-  // deprecated, only for use in Ember 1.11
-  // TODO remove this
-  content: null,
-
   // –––––––––––––– Optional Settings
   staticHeight: false,
 
@@ -84,10 +80,6 @@ const VerticalCollection = Component.extend({
    */
   renderFromLast: false,
 
-  // –––––––––––––– @private
-  // TODO remove this
-  _items: computed.or('items', 'content'),
-
   _calculateMinHeight() {
     const { minHeight } = this;
 
@@ -102,10 +94,10 @@ const VerticalCollection = Component.extend({
 
   supportsInverse: SUPPORTS_INVERSE_BLOCK,
 
-  isEmpty: computed.empty('_items'),
+  isEmpty: computed.empty('items'),
   shouldYieldToInverse: computed.and('isEmpty', 'supportsInverse'),
 
-  radar: computed('_items.[]', function() {
+  radar: computed('items.[]', function() {
     const {
       _radar,
 
@@ -114,7 +106,7 @@ const VerticalCollection = Component.extend({
       _prevLastKey
     } = this;
 
-    const items = this.get('_items');
+    const items = this.get('items');
     const itemsLength = get(items, 'length');
 
     const key = this.get('key');
@@ -206,7 +198,7 @@ const VerticalCollection = Component.extend({
     const key = this.get('key');
 
     const minHeight = this._minHeight;
-    const items = this.get('_items');
+    const items = this.get('items');
     const totalItems = get(items, 'length');
 
     let visibleTop = 0;

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -104,6 +104,12 @@ const VerticalCollection = Component.extend({
     } = this;
 
     const items = this.get('items');
+
+    if (items === null || items === undefined) {
+      _radar.updateItems([], true);
+      return this._radar.virtualComponents;
+    }
+
     const itemsLength = get(items, 'length');
 
     const key = this.get('key');

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -15,7 +15,7 @@ import {
   removeScrollHandler
 } from '../../-private';
 
-import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
+import { assert } from 'vertical-collection/-debug/helpers';
 
 const {
   computed,
@@ -260,7 +260,7 @@ const VerticalCollection = Component.extend({
     this._super();
 
     this._minHeight = this._calculateMinHeight();
-    const RadarClass = this.get('staticHeight') ? StaticRadar : DynamicRadar;
+    const RadarClass = this.staticHeight ? StaticRadar : DynamicRadar;
 
     this.supportsInverse = SUPPORTS_INVERSE_BLOCK;
     this._prevItemsLength = 0;

--- a/addon/components/vertical-collection/template.hbs
+++ b/addon/components/vertical-collection/template.hbs
@@ -1,4 +1,4 @@
-{{#each radar.virtualComponents key="id" as |virtualComponent index| ~}}
+{{#each virtualComponents key="id" as |virtualComponent index| ~}}
   {{~unbound virtualComponent.upperBound~}}
   {{~#if virtualComponent.element ~}}
     {{{unbound virtualComponent.element}}}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,20 +6,18 @@ module.exports = {
       bower: {
         dependencies: {
           'ember': '~1.11.0',
-          'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.3',
-          'ember-data': '~1.13.0'
+          'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.3'
         },
         resolutions: {
           'ember': '~1.11.0',
-          'ember-cli-shims': '0.0.3',
-          'ember-data': '~1.13.0'
+          'ember-cli-shims': '0.0.3'
         }
       },
       npm: {
         devDependencies: {
           'ember-cli-shims': null,
           'ember-cli-fastboot': null,
-          'ember-data': '~1.13.0',
+          'ember-data': null,
           'ember-source': null,
           'fastboot': null
         }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,18 +6,20 @@ module.exports = {
       bower: {
         dependencies: {
           'ember': '~1.11.0',
-          'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.3'
+          'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.3',
+          'ember-data': '~1.13.0'
         },
         resolutions: {
           'ember': '~1.11.0',
-          'ember-cli-shims': '0.0.3'
+          'ember-cli-shims': '0.0.3',
+          'ember-data': '~1.13.0'
         }
       },
       npm: {
         devDependencies: {
           'ember-cli-shims': null,
           'ember-cli-fastboot': null,
-          'ember-data': null,
+          'ember-data': '~1.13.0',
           'ember-source': null,
           'fastboot': null
         }

--- a/tests/acceptance/acceptance-tests/record-array-test.js
+++ b/tests/acceptance/acceptance-tests/record-array-test.js
@@ -1,17 +1,23 @@
+import Ember from 'ember';
 import { test } from 'qunit';
 import moduleForAcceptance from '../../../tests/helpers/module-for-acceptance';
 import wait from 'dummy/tests/helpers/wait';
 
 moduleForAcceptance('Acceptance | Record Array');
 
-test('RecordArrays render correctly', function(assert) {
-  visit('/acceptance-tests/record-array');
+const { VERSION } = Ember;
 
-  andThen(function() {
-    return wait().then(() => {
-      assert.equal(find('number-slide').length, 21, 'correct number of items rendered');
-      assert.equal(find('number-slide:first').text().replace(/\s/g, ''), '0(0)', 'correct first item rendered');
-      assert.equal(find('number-slide:last').text().replace(/\s/g, ''), '20(20)', 'correct last item rendered');
+// Don't test Ember Data pre-1.13, there were no stable releases
+if (VERSION.match(/1\.11\.\d+/) === null) {
+  test('RecordArrays render correctly', function(assert) {
+    visit('/acceptance-tests/record-array');
+
+    andThen(function() {
+      return wait().then(() => {
+        assert.equal(find('number-slide').length, 21, 'correct number of items rendered');
+        assert.equal(find('number-slide:first').text().replace(/\s/g, ''), '0(0)', 'correct first item rendered');
+        assert.equal(find('number-slide:last').text().replace(/\s/g, ''), '20(20)', 'correct last item rendered');
+      });
     });
   });
-});
+}

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -1,6 +1,5 @@
 <div class="table-wrapper dark">
-  {{#vertical-collection
-    items=model
+  {{#vertical-collection model
     minHeight=50
     bufferSize=5
 

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -1,6 +1,6 @@
 <div class="table-wrapper dark">
   {{#vertical-collection
-    content=model
+    items=model
     minHeight=50
     bufferSize=5
 

--- a/tests/dummy/app/routes/examples/reduce-debug/template.hbs
+++ b/tests/dummy/app/routes/examples/reduce-debug/template.hbs
@@ -4,7 +4,7 @@
           <h3>Demo</h3>
           <div class="table-wrapper dark">
             {{#vertical-collection
-              content=model.filtered
+              items=model.filtered
               defaultHeight=270
               useContentProxy=false
               as |item index|
@@ -16,7 +16,7 @@
           </div>
         </div>
         <div class="col-sm-7">
-            <h3>Redcue Debug</h3>
+            <h3>Reduce Debug</h3>
             <p>
                 Ensure we can shrink the array safely.
             </p>

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -129,6 +129,35 @@ test('The collection renders in the correct initial position', function(assert) 
   });
 });
 
+test('The collection renders in the correct initial position with dynamic heights', function(assert) {
+  assert.expect(3);
+
+  this.set('items', getNumbers(0, 100));
+
+  this.render(hbs`
+  <div style="position: relative; background: red; box-sizing: content-box; height: 100px; overflow-y: scroll;" class="scrollable">
+    <div style="padding: 200px;">
+      {{#vertical-collection ${'items'}
+        containerSelector=".scrollable"
+        minHeight=20
+
+        as |item i|}}
+        <vertical-item style="height: 28px">
+          {{item.number}} {{i}}
+        </vertical-item>
+      {{/vertical-collection}}
+    </div>
+  </div>
+  `);
+
+  return wait().then(() => {
+    let occludedBoundaries = this.$().find('occluded-content');
+    assert.equal(occludedBoundaries.get(0).getAttribute('style'), 'height: 0px;', 'Occluded height above is 0');
+    assert.equal(occludedBoundaries.get(1).getAttribute('style'), 'height: 1880px;', 'Occluded height below is 20 * 94 items');
+    assert.equal(this.$().find('vertical-item').length, 6, 'We rendered 100/20 + 1 items');
+  });
+});
+
 test('The collection renders when yielded item has conditional', function(assert) {
   assert.expect(1);
   const items = [{


### PR DESCRIPTION
This adds a (was failing) test for starting a dynamically sized list in a position offset from the top of the scroll-container.

However, this causes the skip-list to need to deal with negative numbers. To handle this, I then changed the determination of `middleVisibleValue` to:

```
let top = this.visibleTop;

if (top < 0) {
  top = 0;
}

const middleVisibleValue = top + (this.scrollContainerHeight / 2);
```