### PR TITLE
[WIP] refactor(radar): startup and resize

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -222,20 +222,20 @@ export default class DynamicRadar extends Radar {
     }
   }
 
-  prepend(items, numPrepended) {
-    super.prepend(items, numPrepended);
+  prepend(numPrepended) {
+    super.prepend(numPrepended);
 
     this.skipList.prepend(numPrepended);
   }
 
-  append(items, numAppended) {
-    super.append(items, numAppended);
+  append(numAppended) {
+    super.append(numAppended);
 
     this.skipList.append(numAppended);
   }
 
-  reset(items) {
-    super.reset(items);
+  reset() {
+    super.reset();
 
     this.skipList = new SkipList(this.totalItems, this.minHeight);
   }

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -35,27 +35,42 @@ export default class DynamicRadar extends Radar {
   }
 
   _updateIndexes() {
-    const { values } = this.skipList;
-    const maxIndex = this.totalItems - 1;
-    const prevFirstItemIndex = this._prevFirstItemIndex;
-    const prevLastItemIndex = this._prevLastItemIndex;
-    const middleVisibleValue = this.visibleMiddle;
-    const { totalComponents } = this;
+    const {
+      skipList,
+      visibleMiddle,
+      totalItems,
+      totalComponents,
+
+      _prevFirstItemIndex,
+      _prevLastItemIndex
+    } = this;
+
+    if (totalItems === 0) {
+      this._firstItemIndex = NULL_INDEX;
+      this._lastItemIndex = NULL_INDEX;
+      this._totalBefore = 0;
+      this._totalAfter = 0;
+
+      return;
+    }
+
+    const { values } = skipList;
+    const maxIndex = totalItems - 1;
 
     // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
     // completely new set of items and won't get an accurate measurement until after they render the
     // first time.
-    if (prevFirstItemIndex !== NULL_INDEX) {
+    if (_prevFirstItemIndex !== NULL_INDEX) {
       // We only need to measure the components that were rendered last time, extra components
       // haven't rendered yet.
-      this._measure(0, prevLastItemIndex - prevFirstItemIndex);
+      this._measure(0, _prevLastItemIndex - _prevFirstItemIndex);
     }
 
     let {
       totalBefore,
       totalAfter,
       index: middleItemIndex
-    } = this.skipList.find(middleVisibleValue);
+    } = this.skipList.find(visibleMiddle);
 
     let firstItemIndex = middleItemIndex - Math.floor((totalComponents - 1) / 2);
     let lastItemIndex = middleItemIndex + Math.ceil((totalComponents - 1) / 2);
@@ -78,7 +93,7 @@ export default class DynamicRadar extends Radar {
       totalAfter -= values[i];
     }
 
-    const itemDelta = (prevFirstItemIndex !== null) ? firstItemIndex - prevFirstItemIndex : 0;
+    const itemDelta = (_prevFirstItemIndex !== null) ? firstItemIndex - _prevFirstItemIndex : 0;
     const numCulled = Math.abs(itemDelta % totalComponents);
 
     if (itemDelta < 0 || this._firstRender === true) {

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -46,7 +46,7 @@ export default class DynamicRadar extends Radar {
       top = 0;
     }
 
-    const middleVisibleValue = top + (this.scrollContainerHeight / 2);
+    const middleVisibleValue = this.visibleMiddle;
 
     // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
     // completely new set of items and won't get an accurate measurement until after they render the

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -157,16 +157,8 @@ export default class DynamicRadar extends Radar {
     return this._firstItemIndex;
   }
 
-  set firstItemIndex(index) {
-    this._firstItemIndex = index;
-  }
-
   get lastItemIndex() {
     return this._lastItemIndex;
-  }
-
-  set lastItemIndex(index) {
-    this._lastItemIndex = index;
   }
 
   get firstVisibleIndex() {

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -37,10 +37,10 @@ export default class DynamicRadar extends Radar {
   _updateIndexes() {
     const { values } = this.skipList;
     const maxIndex = this.totalItems - 1;
-    const numComponents = this.orderedComponents.length;
     const prevFirstItemIndex = this._prevFirstItemIndex;
     const prevLastItemIndex = this._prevLastItemIndex;
     const middleVisibleValue = this.visibleMiddle;
+    const { totalComponents } = this;
 
     // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
     // completely new set of items and won't get an accurate measurement until after they render the
@@ -57,17 +57,17 @@ export default class DynamicRadar extends Radar {
       index: middleItemIndex
     } = this.skipList.find(middleVisibleValue);
 
-    let firstItemIndex = middleItemIndex - Math.floor((numComponents - 1) / 2);
-    let lastItemIndex = middleItemIndex + Math.ceil((numComponents - 1) / 2);
+    let firstItemIndex = middleItemIndex - Math.floor((totalComponents - 1) / 2);
+    let lastItemIndex = middleItemIndex + Math.ceil((totalComponents - 1) / 2);
 
     if (firstItemIndex < 0) {
       firstItemIndex = 0;
-      lastItemIndex = numComponents - 1;
+      lastItemIndex = totalComponents - 1;
     }
 
     if (lastItemIndex > maxIndex) {
       lastItemIndex = maxIndex;
-      firstItemIndex = maxIndex - (numComponents - 1);
+      firstItemIndex = maxIndex - (totalComponents - 1);
     }
 
     for (let i = middleItemIndex - 1; i >= firstItemIndex; i--) {
@@ -79,7 +79,7 @@ export default class DynamicRadar extends Radar {
     }
 
     const itemDelta = (prevFirstItemIndex !== null) ? firstItemIndex - prevFirstItemIndex : 0;
-    const numCulled = Math.abs(itemDelta % numComponents);
+    const numCulled = Math.abs(itemDelta % totalComponents);
 
     if (itemDelta < 0 || this._firstRender === true) {
       // schedule a measurement for items that could affect scrollTop

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -40,12 +40,6 @@ export default class DynamicRadar extends Radar {
     const numComponents = this.orderedComponents.length;
     const prevFirstItemIndex = this._prevFirstItemIndex;
     const prevLastItemIndex = this._prevLastItemIndex;
-    let top = this.visibleTop;
-
-    if (top < 0) {
-      top = 0;
-    }
-
     const middleVisibleValue = this.visibleMiddle;
 
     // Don't measure if the radar has just been instantiated or reset, as we are rendering with a
@@ -93,7 +87,7 @@ export default class DynamicRadar extends Radar {
         const staticVisibleIndex = this.renderFromLast ? this.lastVisibleIndex + 1 : this.firstVisibleIndex;
         const numBeforeStatic = staticVisibleIndex - firstItemIndex;
 
-        const lastIndex = this._firstRender ? numBeforeStatic - 1 : Math.min(numCulled, numBeforeStatic - 1);
+        const lastIndex = this._firstRender ? numBeforeStatic - 1 : Math.max(Math.min(numCulled, numBeforeStatic - 1), 0);
         this._prependOffset += this._measure(0, lastIndex);
         this._firstRender = false;
       });
@@ -233,11 +227,9 @@ export default class DynamicRadar extends Radar {
     this.skipList.append(numAppended);
   }
 
-  updateItems(items, isReset) {
-    super.updateItems(items, isReset);
+  reset(items) {
+    super.reset(items);
 
-    if (isReset === true) {
-      this.skipList = new SkipList(this.totalItems, this.minHeight);
-    }
+    this.skipList = new SkipList(this.totalItems, this.minHeight);
   }
 }

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -355,8 +355,7 @@ export default class Radar {
     }
   }
 
-  prepend(items, numPrepended) {
-    this.items = items;
+  prepend(numPrepended) {
     this._prevFirstItemIndex += numPrepended;
     this._prevLastItemIndex += numPrepended;
 
@@ -369,14 +368,13 @@ export default class Radar {
     this._prependOffset = numPrepended * this.minHeight;
   }
 
-  append(items) {
-    this.items = items;
-
+  append() {
     this._lastReached = false;
   }
 
-  reset(items) {
-    this.items = items;
+  reset() {
+    this._componentPool.push(...this.orderedComponents);
+    this.orderedComponents.length = 0;
 
     this._prevFirstItemIndex = NULL_INDEX;
     this._prevLastItemIndex = NULL_INDEX;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -41,7 +41,7 @@ export default class Radar {
     this._prevLastVisibleIndex = NULL_INDEX;
     this._firstItemIndex = NULL_INDEX;
     this._lastItemIndex = NULL_INDEX;
-    this.scrollContainerHeight = 0;
+    this._scrollContainerHeight = 0;
 
     this._firstReached = false;
     this._lastReached = false;
@@ -71,7 +71,6 @@ export default class Radar {
     this.renderFromLast = renderFromLast;
     this.keyProperty = keyProperty;
 
-    this._updateVirtualComponentPool();
     this.scheduleUpdate();
   }
 
@@ -118,6 +117,7 @@ export default class Radar {
 
       this._scrollTop = this.scrollContainer.scrollTop;
 
+      this._updateVirtualComponentPool();
       this._updateIndexes();
       this._updateVirtualComponents();
 
@@ -184,8 +184,16 @@ export default class Radar {
 
   set scrollContainer(scrollContainer) {
     this._scrollContainer = scrollContainer;
+    this._scrollContainerHeight = null;
     this._scrollTopOffset = null;
-    this.scrollContainerHeight = scrollContainer.getBoundingClientRect().height;
+  }
+
+  get scrollContainerHeight() {
+    if (this._scrollContainerHeight === null) {
+      this._scrollContainerHeight = this.scrollContainer.getBoundingClientRect().height;
+    }
+
+    return this._scrollContainerHeight;
   }
 
   get scrollContainer() {
@@ -267,7 +275,8 @@ export default class Radar {
       totalAfter
     } = this;
 
-    const itemDelta = firstItemIndex - _prevFirstItemIndex;
+
+    const itemDelta = _prevFirstItemIndex !== NULL_INDEX ? firstItemIndex - _prevFirstItemIndex : 0;
     const offsetAmount = Math.abs(itemDelta % orderedComponents.length);
 
     if (offsetAmount > 0) {
@@ -370,7 +379,6 @@ export default class Radar {
 
     this._firstReached = false;
 
-    this._updateVirtualComponentPool();
     this.scheduleUpdate();
 
     this._prependOffset = numPrepended * this.minHeight;
@@ -381,7 +389,6 @@ export default class Radar {
 
     this._lastReached = false;
 
-    this._updateVirtualComponentPool();
     this.scheduleUpdate();
   }
 
@@ -394,8 +401,6 @@ export default class Radar {
 
       this._firstReached = false;
       this._lastReached = false;
-
-      this._updateVirtualComponentPool();
     }
 
     this.scheduleUpdate();

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -196,20 +196,12 @@ export default class Radar {
    */
   _updateVirtualComponentPool() {
     const {
-      _scrollContainerHeight,
-      _minHeight,
-      bufferSize,
       virtualComponents,
       orderedComponents,
-      totalItems,
-      items
+      items,
+      totalComponents
     } = this;
 
-    // The total number of components is determined by the minimum number required to span the
-    // container plus its buffers. Combined with the above rendering strategy this is fairly
-    // performant, even if mean item size is above the minimum.
-    const calculatedComponents = Math.ceil(_scrollContainerHeight / _minHeight) + 1 + (bufferSize * 2);
-    const totalComponents = Math.min(totalItems, calculatedComponents);
     const delta = totalComponents - orderedComponents.length;
 
     if (delta > 0) {
@@ -399,5 +391,20 @@ export default class Radar {
 
   get totalItems() {
     return this.items ? get(this.items, 'length') : 0;
+  }
+
+  get totalComponents() {
+    const {
+      _scrollContainerHeight,
+      _minHeight,
+      bufferSize,
+      totalItems
+    } = this;
+
+    // The total number of components is determined by the minimum number required to span the
+    // container plus its buffers. Combined with the above rendering strategy this is fairly
+    // performant, even if mean item size is above the minimum.
+    const calculatedComponents = Math.ceil(_scrollContainerHeight / _minHeight) + 1 + (bufferSize * 2);
+    return Math.min(totalItems, calculatedComponents);
   }
 }

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -26,7 +26,7 @@ export default class Radar {
     this.items = null;
     this.minHeight = 0;
     this.bufferSize = 0;
-    this.startingScrollTop = 0;
+    this.startingIndex = 0;
     this.renderFromLast = false;
     this.itemContainer = null;
     this.scrollContainer = null;
@@ -78,25 +78,28 @@ export default class Radar {
   }
 
   start() {
-    let { startingScrollTop } = this;
+    let { startingIndex } = this;
 
-    if (this.startingScrollTop !== 0) {
+    if (startingIndex !== 0) {
       this._updateConstants();
 
       const {
-        minHeight,
         totalItems,
         renderFromLast,
-        _scrollTopOffset
+        _minHeight,
+        _scrollTopOffset,
+        _scrollContainerHeight
       } = this;
 
+      let startingScrollTop = startingIndex * _minHeight;
+
       if (renderFromLast) {
-        startingScrollTop -= (this._radar.scrollContainerHeight - minHeight);
+        startingScrollTop -= (_scrollContainerHeight - _minHeight);
       }
 
       // The container element needs to have some height in order for us to set the scroll position
       // on initialization, so we set this min-height property to radar's total
-      this.itemContainer.style.minHeight = `${minHeight * totalItems}px`;
+      this.itemContainer.style.minHeight = `${_minHeight * totalItems}px`;
       this.scrollContainer.scrollTop = startingScrollTop + _scrollTopOffset;
     }
 

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -231,6 +231,13 @@ export default class Radar {
       _componentPool.unshift(orderedComponents.pop());
     }
 
+    // If the underlying array has changed, the indexes could be the same but the content may have changed,
+    // so recycle the remaining components just in case. If content has not changed, this is a no-op.
+    for (let i = 0; i < orderedComponents.length; i++) {
+      const component = orderedComponents[i];
+      component.recycle(objectAt(items, component.index), component.index);
+    }
+
     // If rendered components are empty, add one back so the rest of the logic remains the same
     if (orderedComponents.length === 0 && totalComponents > 0) {
       const component = _componentPool.pop() || new VirtualComponent();
@@ -373,9 +380,6 @@ export default class Radar {
   }
 
   reset() {
-    this._componentPool.push(...this.orderedComponents);
-    this.orderedComponents.length = 0;
-
     this._prevFirstItemIndex = NULL_INDEX;
     this._prevLastItemIndex = NULL_INDEX;
 

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -122,12 +122,6 @@ export default class Radar {
     this._nextUpdate = this.schedule('layout', () => {
       this._nextUpdate = null;
 
-      // cache previous values
-      this._prevFirstItemIndex = this.firstItemIndex;
-      this._prevLastItemIndex = this.lastItemIndex;
-      this._prevFirstVisibleIndex = this.firstVisibleIndex;
-      this._prevLastVisibleIndex = this.lastVisibleIndex;
-
       this._scrollTop = this.scrollContainer.scrollTop;
 
       this._updateConstants();
@@ -144,6 +138,12 @@ export default class Radar {
         if (this.totalItems !== 0) {
           this._sendActions();
         }
+
+        // cache previous values
+        this._prevFirstItemIndex = this.firstItemIndex;
+        this._prevLastItemIndex = this.lastItemIndex;
+        this._prevFirstVisibleIndex = this.firstVisibleIndex;
+        this._prevLastVisibleIndex = this.lastVisibleIndex;
       });
     });
   }
@@ -348,8 +348,8 @@ export default class Radar {
 
   prepend(items, numPrepended) {
     this.items = items;
-    this.firstItemIndex += numPrepended;
-    this.lastItemIndex += numPrepended;
+    this._prevFirstItemIndex += numPrepended;
+    this._prevLastItemIndex += numPrepended;
 
     this._firstReached = false;
 
@@ -365,8 +365,8 @@ export default class Radar {
   reset(items) {
     this.items = items;
 
-    this.firstItemIndex = NULL_INDEX;
-    this.lastItemIndex = NULL_INDEX;
+    this._prevFirstItemIndex = NULL_INDEX;
+    this._prevLastItemIndex = NULL_INDEX;
 
     this._firstReached = false;
     this._lastReached = false;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -238,36 +238,29 @@ export default class Radar {
       component.recycle(objectAt(items, component.index), component.index);
     }
 
-    // If rendered components are empty, add one back so the rest of the logic remains the same
-    if (orderedComponents.length === 0 && totalComponents > 0) {
-      const component = _componentPool.pop() || new VirtualComponent();
+    let firstRenderedIndex = orderedComponents[0] ? orderedComponents[0].index : firstItemIndex;
+    let lastRenderedIndex = orderedComponents[orderedComponents.length - 1] ? orderedComponents[orderedComponents.length - 1].index : firstItemIndex - 1;
 
-      component.recycle(objectAt(items, firstItemIndex), firstItemIndex);
+    // Append as many items as needed to the rendered components
+    while (orderedComponents.length < totalComponents && lastRenderedIndex < lastItemIndex) {
+      const component = _componentPool.pop() || new VirtualComponent();
+      const itemIndex = ++lastRenderedIndex;
+
+      component.recycle(objectAt(items, itemIndex), itemIndex);
       this._appendComponent(component);
 
       orderedComponents.push(component);
     }
 
     // Prepend as many items as needed to the rendered components
-    while (orderedComponents.length < totalComponents && orderedComponents[0].index > firstItemIndex) {
+    while (orderedComponents.length < totalComponents && firstRenderedIndex > firstItemIndex) {
       const component = _componentPool.pop() || new VirtualComponent();
-      const itemIndex = orderedComponents[0].index - 1;
+      const itemIndex = --firstRenderedIndex;
 
       component.recycle(objectAt(items, itemIndex), itemIndex);
       this._prependComponent(component);
 
       orderedComponents.unshift(component);
-    }
-
-    // Append as many items as needed to the rendered components
-    while (orderedComponents.length < totalComponents && orderedComponents[orderedComponents.length - 1].index < lastItemIndex) {
-      const component = _componentPool.pop() || new VirtualComponent();
-      const itemIndex = orderedComponents[orderedComponents.length - 1].index + 1;
-
-      component.recycle(objectAt(items, itemIndex), itemIndex);
-      this._appendComponent(component);
-
-      orderedComponents.push(component);
     }
 
     // If there are any items remaining in the pool, remove them

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -14,23 +14,23 @@ export default class StaticRadar extends Radar {
   }
 
   _updateIndexes() {
-    const totalIndexes = this.orderedComponents.length;
+    const { totalComponents } = this;
     const maxIndex = this.totalItems - 1;
 
     const middleVisibleValue = this.visibleMiddle;
     const middleItemIndex = Math.floor(middleVisibleValue / this.minHeight);
 
-    let firstItemIndex = middleItemIndex - Math.floor((totalIndexes - 1) / 2);
-    let lastItemIndex = middleItemIndex + Math.ceil((totalIndexes - 1) / 2);
+    let firstItemIndex = middleItemIndex - Math.floor((totalComponents - 1) / 2);
+    let lastItemIndex = middleItemIndex + Math.ceil((totalComponents - 1) / 2);
 
     if (firstItemIndex < 0) {
       firstItemIndex = 0;
-      lastItemIndex = totalIndexes - 1;
+      lastItemIndex = totalComponents - 1;
     }
 
     if (lastItemIndex > maxIndex) {
       lastItemIndex = maxIndex;
-      firstItemIndex = maxIndex - (totalIndexes - 1);
+      firstItemIndex = maxIndex - (totalComponents - 1);
     }
 
     this._firstItemIndex = firstItemIndex;

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -17,7 +17,7 @@ export default class StaticRadar extends Radar {
     const totalIndexes = this.orderedComponents.length;
     const maxIndex = this.totalItems - 1;
 
-    const middleVisibleValue = this.visibleTop + ((this.visibleBottom - this.visibleTop)  / 2);
+    const middleVisibleValue = this.visibleMiddle;
     const middleItemIndex = Math.floor(middleVisibleValue / this.minHeight);
 
     let firstItemIndex = middleItemIndex - Math.floor((totalIndexes - 1) / 2);

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -53,16 +53,8 @@ export default class StaticRadar extends Radar {
     return this._firstItemIndex;
   }
 
-  set firstItemIndex(index) {
-    this._firstItemIndex = index;
-  }
-
   get lastItemIndex() {
     return this._lastItemIndex;
-  }
-
-  set lastItemIndex(index) {
-    this._lastItemIndex = index;
   }
 
   get firstVisibleIndex() {

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -14,11 +14,22 @@ export default class StaticRadar extends Radar {
   }
 
   _updateIndexes() {
-    const { totalComponents } = this;
-    const maxIndex = this.totalItems - 1;
+    const {
+      totalComponents,
+      totalItems,
+      visibleMiddle,
+      _minHeight
+    } = this;
 
-    const middleVisibleValue = this.visibleMiddle;
-    const middleItemIndex = Math.floor(middleVisibleValue / this.minHeight);
+    if (totalItems === 0) {
+      this._firstItemIndex = NULL_INDEX;
+      this._lastItemIndex = NULL_INDEX;
+
+      return;
+    }
+
+    const maxIndex = totalItems - 1;
+    const middleItemIndex = Math.floor(visibleMiddle / _minHeight);
 
     let firstItemIndex = middleItemIndex - Math.floor((totalComponents - 1) / 2);
     let lastItemIndex = middleItemIndex + Math.ceil((totalComponents - 1) / 2);
@@ -38,15 +49,15 @@ export default class StaticRadar extends Radar {
   }
 
   get total() {
-    return this.totalItems * this.minHeight;
+    return this.totalItems * this._minHeight;
   }
 
   get totalBefore() {
-    return this.firstItemIndex * this.minHeight;
+    return this.firstItemIndex * this._minHeight;
   }
 
   get totalAfter() {
-    return this.total - ((this.lastItemIndex + 1) * this.minHeight);
+    return this.total - ((this.lastItemIndex + 1) * this._minHeight);
   }
 
   get firstItemIndex() {
@@ -58,13 +69,13 @@ export default class StaticRadar extends Radar {
   }
 
   get firstVisibleIndex() {
-    const firstVisibleIndex = Math.ceil(this.visibleTop / this.minHeight);
+    const firstVisibleIndex = Math.ceil(this.visibleTop / this._minHeight);
 
     return this.firstItemIndex === NULL_INDEX ? NULL_INDEX : firstVisibleIndex;
   }
 
   get lastVisibleIndex() {
-    const lastVisibleIndex = Math.min(Math.ceil(this.visibleBottom / this.minHeight), this.totalItems - 1);
+    const lastVisibleIndex = Math.min(Math.ceil(this.visibleBottom / this._minHeight), this.totalItems - 1);
 
     return this.firstItemIndex === NULL_INDEX ? NULL_INDEX : lastVisibleIndex;
   }

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -28,7 +28,11 @@ export default class SkipList {
   constructor(length, defaultValue) {
     const values = new Float32Array(new ArrayBuffer(length * 4));
 
-    values.fill(defaultValue);
+    if (typeof values.fill === 'function') {
+      values.fill(defaultValue);
+    } else {
+      Array.prototype.fill.call(values, defaultValue);
+    }
 
     this.length = length;
     this.defaultValue = defaultValue;
@@ -173,7 +177,12 @@ export default class SkipList {
     const newValues = new Float32Array(new ArrayBuffer(newLength * 4));
 
     newValues.set(oldValues, numPrepended);
-    newValues.fill(defaultValue, 0, numPrepended);
+
+    if (typeof newValues.fill === 'function') {
+      newValues.fill(defaultValue, 0, numPrepended);
+    } else {
+      Array.prototype.fill.call(newValues, defaultValue, 0, numPrepended);
+    }
 
     this.length = newLength;
     this._initializeLayers(newValues);
@@ -191,7 +200,12 @@ export default class SkipList {
     const newValues = new Float32Array(new ArrayBuffer(newLength * 4));
 
     newValues.set(oldValues);
-    newValues.fill(defaultValue, oldLength);
+
+    if (typeof newValues.fill === 'function') {
+      newValues.fill(defaultValue, oldLength);
+    } else {
+      Array.prototype.fill.call(newValues, defaultValue, oldLength);
+    }
 
     this.length = newLength;
     this._initializeLayers(newValues);

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -18,6 +18,8 @@ export default class VirtualComponent {
     this.lowerBound = document.createTextNode('');
     this.element = null;
 
+    this.rendered = false;
+
     // In older versions of Ember, binding anything on an object in the template
     // adds observers which creates __ember_meta__
     this.__ember_meta__ = null; // eslint-disable-line camelcase

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -8,16 +8,15 @@ const { set } = Ember;
 let VC_IDENTITY = 0;
 
 export default class VirtualComponent {
-  constructor(element) {
+  constructor(content = null, index = null) {
     this.id = VC_IDENTITY++;
 
-    this.element = element;
+    this.content = content;
+    this.index = index;
 
     this.upperBound = document.createTextNode('');
     this.lowerBound = document.createTextNode('');
-
-    this.content = null;
-    this.index = 0;
+    this.element = null;
 
     // In older versions of Ember, binding anything on an object in the template
     // adds observers which creates __ember_meta__

--- a/addon/-private/index.js
+++ b/addon/-private/index.js
@@ -10,7 +10,7 @@ export { default as StaticRadar } from './data-view/radar/static-radar';
 export { default as Container } from './data-view/container';
 export { default as objectAt } from './data-view/utils/object-at';
 
-export { scheduler } from './scheduler/index';
+export { Token, scheduler } from './scheduler/index';
 
 export {
   addScrollHandler,

--- a/addon/-private/scheduler/index.js
+++ b/addon/-private/scheduler/index.js
@@ -76,30 +76,26 @@ export class Scheduler {
 
   flush() {
     let i, q;
-    let hasDomWork = this.sync.length > 0 || this.layout.length > 0;
     this.jobs = 0;
 
-    // TODO add explicit test
-    if (hasDomWork) {
+    if (this.sync.length > 0) {
       run.begin();
-      if (this.sync.length > 0) {
-        q = this.sync;
-        this.sync = [];
+      q = this.sync;
+      this.sync = [];
 
-        for (i = 0; i < q.length; i++) {
-          q[i]();
-        }
-      }
-
-      if (this.layout.length > 0) {
-        q = this.layout;
-        this.layout = [];
-
-        for (i = 0; i < q.length; i++) {
-          q[i]();
-        }
+      for (i = 0; i < q.length; i++) {
+        q[i]();
       }
       run.end();
+    }
+
+    if (this.layout.length > 0) {
+      q = this.layout;
+      this.layout = [];
+
+      for (i = 0; i < q.length; i++) {
+        q[i]();
+      }
     }
 
     if (this.measure.length > 0) {
@@ -109,17 +105,6 @@ export class Scheduler {
       for (i = 0; i < q.length; i++) {
         q[i]();
       }
-    }
-
-    if (this.affect.length > 0) {
-      run.begin();
-      q = this.affect;
-      this.affect = [];
-
-      for (i = 0; i < q.length; i++) {
-        q[i]();
-      }
-      run.end();
     }
 
     this._nextFlush = null;

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -97,13 +97,16 @@ const VerticalCollection = Component.extend({
     const itemsLength = get(items, 'length');
 
     if (items === null || items === undefined || itemsLength === 0) {
-      _radar.reset([]);
+      _radar.items = [];
+      _radar.reset();
       _radar.scheduleUpdate();
 
       this._prevItemsLength = this._prevFirstKey = this._prevLastKey = 0;
 
       return _radar.virtualComponents;
     }
+
+    _radar.items = items;
 
     const key = this.get('key');
     const lenDiff = itemsLength - _prevItemsLength;

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -167,7 +167,7 @@ const VerticalCollection = Component.extend({
     this._initializeScrollState();
     this._initializeEventHandlers();
 
-    this.schedule('layout', () => {
+    this.schedule('sync', () => {
       this._radar.start();
     });
   },

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -180,9 +180,8 @@ const VerticalCollection = Component.extend({
   _initializeRadar() {
     const {
       _radar,
-
-      element,
-      _scrollContainer
+      _scrollContainer,
+      element
     } = this;
 
     _radar.itemContainer = element;
@@ -194,25 +193,24 @@ const VerticalCollection = Component.extend({
     const idForFirstItem = this.get('idForFirstItem');
     const key = this.get('key');
 
-    const minHeight = this._minHeight;
     const items = this.get('items');
     const totalItems = get(items, 'length');
 
-    let startingScrollTop = 0;
+    let startingIndex = 0;
 
-    if (idForFirstItem !== null) {
+    if (idForFirstItem !== undefined) {
       for (let i = 0; i < totalItems - 1; i++) {
         if (keyForItem(objectAt(items, i), key, i) === idForFirstItem) {
-          startingScrollTop = i * minHeight;
+          startingIndex = i;
           break;
         }
       }
     } else if (renderFromLast === true) {
       // If no id was set and `renderFromLast` is true, start from the bottom
-      startingScrollTop = (totalItems - 1) * minHeight;
+      startingIndex = totalItems - 1;
     }
 
-    this._radar.startingScrollTop = startingScrollTop;
+    this._radar.startingIndex = startingIndex;
   },
 
   _initializeEventHandlers() {

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -206,25 +206,20 @@ const VerticalCollection = Component.extend({
 
     let visibleTop = 0;
 
-    // TODO add explicit test
-    if (idForFirstItem) {
+    if (idForFirstItem !== null) {
       for (let i = 0; i < totalItems - 1; i++) {
-        // TODO strict equality
-        if (keyForItem(objectAt(items, i), key, i) == idForFirstItem) {
+        if (keyForItem(objectAt(items, i), key, i) === idForFirstItem) {
           visibleTop = i * minHeight;
           break;
         }
       }
 
-      // TODO add explicit test
-    } else if (renderFromLast) {
+      if (renderFromLast === true) {
+        visibleTop -= (this._radar.scrollContainerHeight - minHeight);
+      }
+    } else if (renderFromLast === true) {
       // If no id was set and `renderFromLast` is true, start from the bottom
       visibleTop = (totalItems - 1) * minHeight;
-    }
-
-    // TODO add explicit test
-    if (renderFromLast) {
-      visibleTop -= (this._radar.scrollContainerHeight - minHeight);
     }
 
     // The container element needs to have some height in order for us to set the scroll position
@@ -233,7 +228,9 @@ const VerticalCollection = Component.extend({
 
     visibleTop -= this._radar.scrollTopOffset;
 
-    this._radar.visibleTop = visibleTop;
+    if (this._radar.visibleTop !== visibleTop) {
+      this._radar.visibleTop = visibleTop;
+    }
   },
 
   _initializeEventHandlers() {
@@ -247,7 +244,7 @@ const VerticalCollection = Component.extend({
     };
 
     this._resizeHandler = () => {
-      this._initializeRadar();
+      this._radar._scrollContainerHeight = null;
     };
 
     addScrollHandler(this._scrollContainer, this._scrollHandler);

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -228,13 +228,13 @@ const VerticalCollection = Component.extend({
 
     visibleTop -= this._radar.scrollTopOffset;
 
-    if (this._radar.visibleTop !== visibleTop) {
-      this._radar.visibleTop = visibleTop;
-    }
+    // if (this._radar.visibleTop !== visibleTop) {
+    //   this._radar.visibleTop = visibleTop;
+    // }
   },
 
   _initializeEventHandlers() {
-    this._lastEarthquake = this._radar.scrollTop;
+    this._lastEarthquake = 0;
 
     this._scrollHandler = ({ top }) => {
       if (Math.abs(this._lastEarthquake - top) > this._minHeight / 2) {
@@ -244,7 +244,7 @@ const VerticalCollection = Component.extend({
     };
 
     this._resizeHandler = () => {
-      this._radar._scrollContainerHeight = null;
+      this._radar.scheduleUpdate();
     };
 
     addScrollHandler(this._scrollContainer, this._scrollHandler);

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -116,11 +116,11 @@ const VerticalCollection = Component.extend({
     this._prevLastKey = keyForItem(objectAt(items, itemsLength - 1), key, itemsLength - 1);
 
     if (isPrepend(lenDiff, items, key, _prevFirstKey, _prevLastKey) === true) {
-      _radar.prepend(items, lenDiff);
+      _radar.prepend(lenDiff);
     } else if (isAppend(lenDiff, items, key, _prevFirstKey, _prevLastKey) === true) {
-      _radar.append(items, lenDiff);
+      _radar.append(lenDiff);
     } else if (isSameArray(lenDiff, items, key, _prevFirstKey, _prevLastKey) === false) {
-      _radar.reset(items);
+      _radar.reset();
     }
 
     _radar.scheduleUpdate();

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ember-cli-changelog": "0.3.4",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "3.0.0",
-    "ember-cli-fastboot": "^1.0.0-beta.18",
     "ember-cli-github-pages": "^0.1.2",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^1.4.1",

--- a/tests/helpers/wait.js
+++ b/tests/helpers/wait.js
@@ -4,7 +4,8 @@ import wait from 'ember-test-helpers/wait';
 export default function() {
   return wait().then(() => {
     return new Ember.RSVP.Promise((resolve) => {
-      requestAnimationFrame(resolve);
+      // Two RAFs needed since we take 3 frames to do the initial render
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
     });
   });
 }

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -240,6 +240,30 @@ testScenarios(
   }
 );
 
+testScenarios(
+  'Collection will rerender items after reset',
+  standardTemplate,
+  scenariosFor(getNumbers(0, 10)),
+
+  function(assert) {
+    assert.expect(4);
+
+    const scrollContainer = this.$('.scrollable');
+
+    return wait().then(() => {
+      assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before append');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before append');
+
+      this.set('items', getNumbers(10, 10));
+
+      return wait();
+    }).then(() => {
+      assert.equal(scrollContainer.find('div:first').text().trim(), '10 0', 'first item rendered correctly after reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '19 9', 'last item rendered correctly after reset');
+    });
+  }
+);
+
 test('Dynamic collection maintains state if the same list is passed in twice', function(assert) {
   assert.expect(4);
   const items = getNumbers(0, 100);

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -37,7 +37,7 @@ testScenarios(
 testScenarios(
   'Setting idForFirstItem starts it with the first item at the top',
   standardTemplate,
-  standardScenariosFor(getNumbers(0, 50), { idForFirstItem: 25, key: '@index' }),
+  standardScenariosFor(getNumbers(0, 50), { idForFirstItem: '25', key: '@index' }),
 
   function(assert) {
     assert.expect(1);
@@ -54,7 +54,7 @@ testScenarios(
 testScenarios(
   'Setting renderFromLast and idForFirstItem starts it with the first item at the bottom',
   standardTemplate,
-  standardScenariosFor(getNumbers(0, 50), { renderFromLast: true, idForFirstItem: 25, key: '@index' }),
+  standardScenariosFor(getNumbers(0, 50), { renderFromLast: true, idForFirstItem: '25', key: '@index' }),
 
   function(assert) {
     assert.expect(1);
@@ -87,7 +87,7 @@ testScenarios(
       called();
     });
 
-    wait().then(() => this.$('.scrollable').scrollTop(200));
+    return wait().then(() => this.$('.scrollable').scrollTop(200));
   }
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1165,7 +1165,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1332,7 +1332,7 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
     rsvp "^3.0.16"
     walk-sync "^0.3.0"
 
-broccoli-string-replace@^0.1.1, broccoli-string-replace@^0.1.2:
+broccoli-string-replace@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz#1ed92f85680af8d503023925e754e4e33676b91f"
   dependencies:
@@ -1352,10 +1352,6 @@ broccoli-uglify-sourcemap@^1.0.0:
     symlink-or-copy "^1.0.1"
     uglify-js "^2.7.0"
     walk-sync "^0.1.3"
-
-broccoli-unwatched-tree@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-unwatched-tree/-/broccoli-unwatched-tree-0.1.1.tgz#4312fde04bdafe67a05a967d72cc50b184a9f514"
 
 broccoli-writer@^0.1.1, broccoli-writer@~0.1.1:
   version "0.1.1"
@@ -2271,35 +2267,6 @@ ember-cli-lodash-subset@^1.0.11, ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
 
-ember-cli-mirage@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.3.1.tgz#2541d624f4994fae3188fcd76a768e8eaff71c4b"
-  dependencies:
-    broccoli-funnel "^1.0.2"
-    broccoli-merge-trees "^1.1.0"
-    broccoli-unwatched-tree "^0.1.1"
-    chalk "^1.1.1"
-    ember-cli-babel "^5.1.7"
-    ember-cli-node-assets "^0.1.4"
-    ember-inflector "^1.9.2"
-    ember-lodash "^4.0"
-    exists-sync "0.0.3"
-    fake-xml-http-request "^1.4.0"
-    faker "^3.0.0"
-    pretender "^1.4.2"
-    route-recognizer "^0.2.3"
-
-ember-cli-node-assets@^0.1.4:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.1.6.tgz#6488a2949048c801ad6d9e33753c7bce32fc1146"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-unwatched-tree "^0.1.1"
-    debug "^2.2.0"
-    lodash "^4.5.1"
-    resolve "^1.1.7"
-
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz#0b14f7bcbc599aa117b5fddc81e4fd03c4bad5b7"
@@ -2547,7 +2514,7 @@ ember-export-application-global@^1.0.5:
   dependencies:
     ember-cli-babel "^5.1.10"
 
-ember-inflector@^1.9.2, ember-inflector@^1.9.4:
+ember-inflector@^1.9.4:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-1.11.0.tgz#99baae18e2bee53cfa97d8db1d739280289a174f"
   dependencies:
@@ -2559,15 +2526,11 @@ ember-load-initializers@^0.6.0:
   dependencies:
     ember-cli-babel "^5.1.6"
 
-ember-lodash@^4.0:
-  version "4.17.2"
-  resolved "https://registry.yarnpkg.com/ember-lodash/-/ember-lodash-4.17.2.tgz#0ed40ab89c2f9846765fc2504c0034000f666933"
+ember-perf-timeline@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ember-perf-timeline/-/ember-perf-timeline-1.2.1.tgz#fb378332f3b739ff5f8ce1439ab67ac45574d6c6"
   dependencies:
-    broccoli-funnel "^1.1.0"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-string-replace "^0.1.1"
     ember-cli-babel "^5.1.7"
-    lodash-es "^4.17.4"
 
 ember-qunit@^2.0.0-beta.1:
   version "2.1.2"
@@ -3062,14 +3025,6 @@ extsprintf@1.0.2:
 eyes@0.1.x:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
-
-fake-xml-http-request@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-1.4.0.tgz#6481c727a0eae9c420bae229dcdfc5369c4b5477"
-
-faker@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-3.1.0.tgz#0f908faf4e6ec02524e54a57e432c5c013e08c9f"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -4161,10 +4116,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
-
 lodash._arraycopy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz#76e7b7c1f1fb92547374878a562ed06a3e50f6e1"
@@ -4351,7 +4302,7 @@ lodash@^3.10.0, lodash@^3.10.1, lodash@^3.3.1, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5000,13 +4951,6 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-pretender@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/pretender/-/pretender-1.4.2.tgz#dde9995dfdf75b28a3dd7a73cde2f9f612e5e8f4"
-  dependencies:
-    fake-xml-http-request "^1.4.0"
-    route-recognizer "^0.2.3"
-
 printf@^0.2.3:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/printf/-/printf-0.2.5.tgz#c438ca2ca33e3927671db4ab69c0e52f936a4f0f"
@@ -5421,10 +5365,6 @@ rollup@^0.41.4:
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
   dependencies:
     source-map-support "^0.4.0"
-
-route-recognizer@^0.2.3:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.2.10.tgz#024b2283c2e68d13a7c7f5173a5924645e8902df"
 
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.4.0:
   version "3.5.0"


### PR DESCRIPTION
This PR does a few things mostly centered around normalizing the `scheduleUpdate` function so that we are:

1. Deferring all work into a RAF, both so measurements are much lower cost and so we don't block the critical path to rendering
2. Always remeasuring so that the internal values we run against are always up to date (`scrollContainerHeight`, `scrollTopOffset`, etc).
3. Always updating everything, including the VC pool

It drops the confusing system of getters/setters for these values and replaces them with a pipeline where every stage of rendering is clearly defined and always happens at a specific point, giving us direct control over where and when we decide to measure and allowing us to prevent forced layouts much more easily.

Still working on this, I'd like to figure out a way to avoid the extra `run` that's been added in `updateVirtualComponentPool`. The issue there is that we want to update the number of VCs if needed, but if we do we can't move _any_ of the VCs around until the new ones render, otherwise it'll cause issues with Glimmer. We can eat the cost of the second `run`, or rerender every component if the VC pool updates, or possibly try to stop doing the DOM manipulation at all.