### PR TITLE
bugfix(prepend): Fixes measuring when prepending items and scrolling up

### DIFF
--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -138,7 +138,10 @@ export default class Radar {
       this._updateVirtualComponents();
 
       this.schedule('measure', () => {
-        if (this.scrollContainer.scrollTop - this._scrollTopOffset !== this.visibleTop) {
+        // If there is a prependOffset of some kind _and_ the scrollTop has changed. Chrome will
+        // automatically change the scrollTop for us in certain situations, which is why we need
+        // to check the cache.
+        if (this._prependOffset !== 0 && this._scrollTop === this.scrollContainer.scrollTop) {
           this.scrollContainer.scrollTop += this._prependOffset;
         }
 

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -202,7 +202,7 @@ const VerticalCollection = Component.extend({
     let startingIndex = 0;
 
     if (idForFirstItem !== undefined) {
-      for (let i = 0; i < totalItems - 1; i++) {
+      for (let i = 0; i < totalItems; i++) {
         if (keyForItem(objectAt(items, i), key, i) === idForFirstItem) {
           startingIndex = i;
           break;


### PR DESCRIPTION
This PR fixes 3 bugs:

1. Deltas when scrolling up are now measured as floats, but `scrollTop` is only ever an integer, so we need to round them to make sure that when we compare the actual scrollTop of the container to our measured version they are the same.
2. When doing the first measure during a prepend, we used the `firstItemIndex` to set measured values in the skipList. This was incorrect because the prepend pushes items forward, so we need to use `_prevFirstItemIndex` instead (value that gets modified in a prepend).
3. When finding the item that matches `idForFirstItem`, we wouldn't iterate over the entire array, meaning if the id were for the last item it would not be found.