### PR TITLE
perf(initial render): Adds scroll handlers inside the initial RAF

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -168,9 +168,9 @@ const VerticalCollection = Component.extend({
     // Initialize the Radar and set the scroll state
     this._initializeRadar();
     this._initializeScrollState();
-    this._initializeEventHandlers();
 
     this.schedule('sync', () => {
+      this._initializeEventHandlers();
       this._radar.start();
     });
   },


### PR DESCRIPTION
The ScrollHandler has to read the initial state of the scrollContainer (scrollTop + scrollLeft) to be able to know if a scroll event has actually caused a change. Doing that directly in `didInsertElement` will cause a forced layout, so it's a better idea to schedule it inside of the first RAF.

Timeline Before:

![screen shot 2017-05-23 at 12 09 50 pm](https://cloud.githubusercontent.com/assets/685518/26371978/4627b8fa-3fb1-11e7-8a2a-dbc376d0e62a.png)

Timelines After: 

![screen shot 2017-05-23 at 12 08 35 pm](https://cloud.githubusercontent.com/assets/685518/26371995/51139446-3fb1-11e7-9a2d-edf170d029b1.png)

![screen shot 2017-05-23 at 12 09 06 pm](https://cloud.githubusercontent.com/assets/685518/26372011/5bf0253c-3fb1-11e7-87ab-3204a074db6a.png)
