### PR TITLE
bugfix(ie): Array.prototype.fill doesn't exist in IE

### DIFF
--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -24,11 +24,18 @@ import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
  * traverse to get the total value before and after the final index.
  */
 
-function fill(array, ...args) {
+function fill(array, value, start, end) {
   if (typeof array.fill === 'function') {
-    array.fill(...args);
+    array.fill(value, start, end);
   } else {
-    Array.prototype.fill.call(array, args);
+    let s = start || 0;
+    const e = end || array.length;
+
+    for (; s < e; s++) {
+      array[s] = value;
+    }
+
+    return array;
   }
 }
 


### PR DESCRIPTION
Uses the same strategy as in Heimdall to polyfill `fill`: https://github.com/heimdalljs/heimdalljs-lib/blob/master/src/shared/array-fill.ts

Note the Heimdall uses TypedArrays' existence to determine whether or not `fill` should be used, but this doesn't appear to be correct. TypedArrays existed as far back as IE10, but none of the IE's support `fill`. Safari also has this issue.