### PR TITLE
feature(init): Adds initialRenderCount option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ dist: trusty
 sudo: false
 
 addons:
-  apt:
-    sources:
-    - google-chrome
-    packages:
-    - google-chrome-stable
+  chrome: stable
 
 cache:
   yarn: true

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -4,8 +4,8 @@ import SkipList from '../skip-list';
 import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
 
 export default class DynamicRadar extends Radar {
-  constructor() {
-    super();
+  constructor(parentToken, initialItems, initialRenderCount, startingIndex) {
+    super(parentToken, initialItems, initialRenderCount, startingIndex);
 
     this._firstItemIndex = NULL_INDEX;
     this._lastItemIndex = NULL_INDEX;

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -2,8 +2,8 @@ import { default as Radar, NULL_INDEX } from './radar';
 import { stripInProduction } from 'vertical-collection/-debug/helpers';
 
 export default class StaticRadar extends Radar {
-  constructor() {
-    super();
+  constructor(parentToken, initialItems, initialRenderCount, startingIndex) {
+    super(parentToken, initialItems, initialRenderCount, startingIndex);
 
     this._firstItemIndex = NULL_INDEX;
     this._lastItemIndex = NULL_INDEX;

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -185,6 +185,97 @@ test('The collection renders when yielded item has conditional', function(assert
   });
 });
 
+test('The collection renders the initialRenderCount correctly', function(assert) {
+  assert.expect(5);
+  this.set('items', getNumbers(0, 100));
+
+  this.render(hbs`
+    <div style="height: 500px; width: 500px;" class="scrollable">
+      {{#vertical-collection ${'items'}
+        minHeight=50
+        initialRenderCount=1
+        as |item i|
+      }}
+        <vertical-item style="height: 50px">
+          {{item.number}} {{i}}
+        </vertical-item>
+      {{/vertical-collection}}
+    </div>
+  `);
+
+  requestAnimationFrame(() => {
+    assert.equal(this.$('vertical-item').length, 1, 'correct number of items rendered on initial pass');
+    assert.equal(this.$('vertical-item').text().trim(), '0 0', 'correct item rendered');
+  });
+
+  return wait().then(() => {
+    assert.equal(this.$('vertical-item').length, 11, 'correctly updates the number of items rendered on second pass');
+    assert.equal(this.$('vertical-item:eq(0)').text().trim(), '0 0', 'correct first item rendered');
+    assert.equal(this.$('vertical-item:eq(10)').text().trim(), '10 10', 'correct last item rendered');
+  });
+});
+
+test('The collection renders the initialRenderCount correctly if idForFirstItem is set', function(assert) {
+  assert.expect(5);
+  this.set('items', getNumbers(0, 100));
+
+  this.render(hbs`
+    <div style="height: 500px; width: 500px;" class="scrollable">
+      {{#vertical-collection ${'items'}
+        minHeight=50
+        initialRenderCount=1
+        idForFirstItem="20"
+        key="number"
+        as |item i|
+      }}
+        <vertical-item style="height: 50px">
+          {{item.number}} {{i}}
+        </vertical-item>
+      {{/vertical-collection}}
+    </div>
+  `);
+
+  requestAnimationFrame(() => {
+    assert.equal(this.$('vertical-item').length, 1, 'correct number of items rendered on initial pass');
+    assert.equal(this.$('vertical-item').text().trim(), '20 20', 'correct item rendered');
+  });
+
+  return wait().then(() => {
+    assert.equal(this.$('vertical-item').length, 11, 'correctly updates the number of items rendered on second pass');
+    assert.equal(this.$('vertical-item:eq(0)').text().trim(), '20 20', 'correct first item rendered');
+    assert.equal(this.$('vertical-item:eq(10)').text().trim(), '30 30', 'correct last item rendered');
+  });
+});
+
+test('The collection renders the initialRenderCount correctly if the count is more than the number of items', function(assert) {
+  assert.expect(4);
+  this.set('items', getNumbers(0, 1));
+
+  this.render(hbs`
+    <div style="height: 500px; width: 500px;" class="scrollable">
+      {{#vertical-collection ${'items'}
+        minHeight=50
+        initialRenderCount=5
+        as |item i|
+      }}
+        <vertical-item style="height: 50px">
+          {{item.number}} {{i}}
+        </vertical-item>
+      {{/vertical-collection}}
+    </div>
+  `);
+
+  requestAnimationFrame(() => {
+    assert.equal(this.$('vertical-item').length, 1, 'correct number of items rendered on initial pass');
+    assert.equal(this.$('vertical-item').text().trim(), '0 0', 'correct item rendered');
+  });
+
+  return wait().then(() => {
+    assert.equal(this.$('vertical-item').length, 1, 'correctly updates the number of items rendered on second pass');
+    assert.equal(this.$('vertical-item').text().trim(), '0 0', 'correct first item rendered');
+  });
+});
+
 /*
 test("The Collection Reveals it's children when `renderAllInitially` is true.", function(assert) {
   assert.expect(1);


### PR DESCRIPTION
Adds an `initialRenderCount` option which will render a static number of items on the first pass. This allows users to: 

A. Not take the initial perf hit on first render from rendering so many items inside of a RAF and
B. Specify a number to be rendered for things like Fastboot

Timelines before:

![screen shot 2017-06-02 at 4 57 05 pm](https://cloud.githubusercontent.com/assets/685518/26749178/f2950c76-47ba-11e7-8e67-c6cc53dd415b.png)

![screen shot 2017-06-02 at 4 57 02 pm](https://cloud.githubusercontent.com/assets/685518/26749174/ed2ba8b2-47ba-11e7-871f-1555c283e3ca.png)

Timelines after:

![screen shot 2017-06-02 at 4 57 42 pm](https://cloud.githubusercontent.com/assets/685518/26749184/fdeb73e4-47ba-11e7-867e-ee964711c489.png)

![screen shot 2017-06-02 at 4 57 34 pm](https://cloud.githubusercontent.com/assets/685518/26749185/008bc0fe-47bb-11e7-999e-bb3aced6d699.png)

