### PR TITLE
refactor(minHeight): Removes minHeight constraints

### DIFF
--- a/addon/-debug/edge-visualization/visualization.js
+++ b/addon/-debug/edge-visualization/visualization.js
@@ -6,7 +6,7 @@ const SYS_WIDTH = 250;
 export default class Visualization {
   constructor(component) {
     this.component = component;
-    this.minimumMovement = Math.floor(component.get('_minHeight') / 2);
+    this.minimumMovement = Math.floor(component.get('_estimateHeight') / 2);
     this.radar = component._radar;
     this.satellites = [];
     this.cache = [];

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -1,7 +1,7 @@
 import { default as Radar, NULL_INDEX } from './radar';
 import SkipList from '../skip-list';
 
-import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
+import { stripInProduction } from 'vertical-collection/-debug/helpers';
 
 export default class DynamicRadar extends Radar {
   constructor(parentToken, initialItems, initialRenderCount, startingIndex) {
@@ -20,12 +20,6 @@ export default class DynamicRadar extends Radar {
     stripInProduction(() => {
       Object.preventExtensions(this);
     });
-  }
-
-  init(...args) {
-    super.init(...args);
-
-    this.skipList = new SkipList(this.totalItems, this.minHeight);
   }
 
   destroy() {
@@ -142,8 +136,6 @@ export default class DynamicRadar extends Radar {
         margin = currentItemTop - itemContainer.getBoundingClientRect().top - totalBefore;
       }
 
-      assert(`item height + margin must always be above the minimum value ${this.minHeight}px. The item at index ${itemIndex} measured: ${currentItemHeight + margin}`, currentItemHeight + margin >= this.minHeight);
-
       const itemDelta = skipList.set(itemIndex, currentItemHeight + margin);
 
       if (itemDelta !== 0) {
@@ -235,6 +227,6 @@ export default class DynamicRadar extends Radar {
   reset() {
     super.reset();
 
-    this.skipList = new SkipList(this.totalItems, this.minHeight);
+    this.skipList = new SkipList(this.totalItems, this.estimateHeight);
   }
 }

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -25,7 +25,7 @@ export default class Radar {
     this.token = new Token(parentToken);
 
     this.items = initialItems;
-    this.minHeight = 0;
+    this.estimateHeight = 0;
     this.bufferSize = 0;
     this.startingIndex = startingIndex;
     this.renderFromLast = false;
@@ -34,7 +34,7 @@ export default class Radar {
 
     this._scrollTop = 0;
     this._prependOffset = 0;
-    this._minHeight = 0;
+    this._estimateHeight = 0;
     this._scrollTopOffset = 0;
     this._scrollContainerHeight = 0;
 
@@ -107,23 +107,23 @@ export default class Radar {
       const {
         totalItems,
         renderFromLast,
-        _minHeight,
+        _estimateHeight,
         _scrollTopOffset,
         _scrollContainerHeight
       } = this;
 
-      let startingScrollTop = startingIndex * _minHeight;
+      let startingScrollTop = startingIndex * _estimateHeight;
 
       if (renderFromLast) {
-        startingScrollTop -= (_scrollContainerHeight - _minHeight);
+        startingScrollTop -= (_scrollContainerHeight - _estimateHeight);
       }
 
       // The container element needs to have some height in order for us to set the scroll position
       // on initialization, so we set this min-height property to radar's total
-      this.itemContainer.style.minHeight = `${_minHeight * totalItems}px`;
+      this.itemContainer.style.minHeight = `${_estimateHeight * totalItems}px`;
       this.scrollContainer.scrollTop = startingScrollTop + _scrollTopOffset;
 
-      this._occludedContentBefore.element.style.height = `${startingIndex * _minHeight}px`;
+      this._occludedContentBefore.element.style.height = `${startingIndex * _estimateHeight}px`;
     }
 
     this._started = true;
@@ -181,12 +181,12 @@ export default class Radar {
 
   _updateConstants() {
     const {
-      minHeight,
+      estimateHeight,
       itemContainer,
       scrollContainer
     } = this;
 
-    assert('Must provide a `minHeight` value to vertical-collection', minHeight !== null);
+    assert('Must provide a `estimateHeight` value to vertical-collection', estimateHeight !== null);
     assert('itemContainer must be set on Radar before scheduling an update', itemContainer !== null);
     assert('scrollContainer must be set on Radar before scheduling an update', scrollContainer !== null);
 
@@ -200,7 +200,7 @@ export default class Radar {
 
     const maxHeight = scrollContainer.style ? parseInt(scrollContainer.style.maxHeight || 0) : 0;
 
-    this._minHeight = typeof minHeight === 'string' ? estimateElementHeight(itemContainer, minHeight) : minHeight;
+    this._estimateHeight = typeof estimateHeight === 'string' ? estimateElementHeight(itemContainer, estimateHeight) : estimateHeight;
     this._scrollTopOffset = this._scrollTop + itemContainerTop - scrollContainerTop;
     this._scrollContainerHeight = Math.max(scrollContainerHeight, maxHeight);
   }
@@ -387,7 +387,7 @@ export default class Radar {
 
     this._firstReached = false;
 
-    this._prependOffset = numPrepended * this.minHeight;
+    this._prependOffset = numPrepended * this.estimateHeight;
   }
 
   append() {
@@ -406,7 +406,7 @@ export default class Radar {
    * `prependOffset` exists because there are times when we need to do the following in this exact
    * order:
    *
-   * 1. Prepend, which means we need to adjust the scroll position by `minHeight * numPrepended`
+   * 1. Prepend, which means we need to adjust the scroll position by `estimateHeight * numPrepended`
    * 2. Calculate the items that will be displayed after the prepend, and move VCs around as
    *    necessary (`scheduleUpdate`).
    * 3. Actually add the amount prepended to `scrollContainer.scrollTop`
@@ -434,7 +434,7 @@ export default class Radar {
   get totalComponents() {
     const {
       _scrollContainerHeight,
-      _minHeight,
+      _estimateHeight,
       bufferSize,
       totalItems
     } = this;
@@ -442,7 +442,7 @@ export default class Radar {
     // The total number of components is determined by the minimum number required to span the
     // container plus its buffers. Combined with the above rendering strategy this is fairly
     // performant, even if mean item size is above the minimum.
-    const calculatedComponents = Math.ceil(_scrollContainerHeight / _minHeight) + 1 + (bufferSize * 2);
+    const calculatedComponents = Math.ceil(_scrollContainerHeight / _estimateHeight) + 1 + (bufferSize * 2);
     return Math.min(totalItems, calculatedComponents);
   }
 }

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -387,7 +387,7 @@ export default class Radar {
 
     this._firstReached = false;
 
-    this._prependOffset = numPrepended * this.estimateHeight;
+    this._prependOffset = numPrepended * this._estimateHeight;
   }
 
   append() {
@@ -432,17 +432,6 @@ export default class Radar {
   }
 
   get totalComponents() {
-    const {
-      _scrollContainerHeight,
-      _estimateHeight,
-      bufferSize,
-      totalItems
-    } = this;
-
-    // The total number of components is determined by the minimum number required to span the
-    // container plus its buffers. Combined with the above rendering strategy this is fairly
-    // performant, even if mean item size is above the minimum.
-    const calculatedComponents = Math.ceil(_scrollContainerHeight / _estimateHeight) + 1 + (bufferSize * 2);
-    return Math.min(totalItems, calculatedComponents);
+    return Math.min(this.totalItems, (this._lastItemIndex - this._firstItemIndex) + 1);
   }
 }

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -18,7 +18,7 @@ export default class StaticRadar extends Radar {
       totalComponents,
       totalItems,
       visibleMiddle,
-      _minHeight
+      _estimateHeight
     } = this;
 
     if (totalItems === 0) {
@@ -29,7 +29,7 @@ export default class StaticRadar extends Radar {
     }
 
     const maxIndex = totalItems - 1;
-    const middleItemIndex = Math.floor(visibleMiddle / _minHeight);
+    const middleItemIndex = Math.floor(visibleMiddle / _estimateHeight);
 
     let firstItemIndex = middleItemIndex - Math.floor((totalComponents - 1) / 2);
     let lastItemIndex = middleItemIndex + Math.ceil((totalComponents - 1) / 2);
@@ -49,15 +49,15 @@ export default class StaticRadar extends Radar {
   }
 
   get total() {
-    return this.totalItems * this._minHeight;
+    return this.totalItems * this._estimateHeight;
   }
 
   get totalBefore() {
-    return this.firstItemIndex * this._minHeight;
+    return this.firstItemIndex * this._estimateHeight;
   }
 
   get totalAfter() {
-    return this.total - ((this.lastItemIndex + 1) * this._minHeight);
+    return this.total - ((this.lastItemIndex + 1) * this._estimateHeight);
   }
 
   get firstItemIndex() {
@@ -69,13 +69,13 @@ export default class StaticRadar extends Radar {
   }
 
   get firstVisibleIndex() {
-    const firstVisibleIndex = Math.ceil(this.visibleTop / this._minHeight);
+    const firstVisibleIndex = Math.ceil(this.visibleTop / this._estimateHeight);
 
     return this.firstItemIndex === NULL_INDEX ? NULL_INDEX : firstVisibleIndex;
   }
 
   get lastVisibleIndex() {
-    const lastVisibleIndex = Math.min(Math.ceil(this.visibleBottom / this._minHeight), this.totalItems - 1);
+    const lastVisibleIndex = Math.min(Math.ceil(this.visibleBottom / this._estimateHeight), this.totalItems - 1);
 
     return this.firstItemIndex === NULL_INDEX ? NULL_INDEX : lastVisibleIndex;
   }

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -15,9 +15,10 @@ export default class StaticRadar extends Radar {
 
   _updateIndexes() {
     const {
-      totalComponents,
+      bufferSize,
       totalItems,
-      visibleMiddle,
+      visibleTop,
+      visibleBottom,
       _estimateHeight
     } = this;
 
@@ -29,20 +30,12 @@ export default class StaticRadar extends Radar {
     }
 
     const maxIndex = totalItems - 1;
-    const middleItemIndex = Math.floor(visibleMiddle / _estimateHeight);
 
-    let firstItemIndex = middleItemIndex - Math.floor((totalComponents - 1) / 2);
-    let lastItemIndex = middleItemIndex + Math.ceil((totalComponents - 1) / 2);
+    let firstItemIndex = Math.floor(visibleTop / _estimateHeight);
+    firstItemIndex = Math.max(0, firstItemIndex - bufferSize);
 
-    if (firstItemIndex < 0) {
-      firstItemIndex = 0;
-      lastItemIndex = totalComponents - 1;
-    }
-
-    if (lastItemIndex > maxIndex) {
-      lastItemIndex = maxIndex;
-      firstItemIndex = maxIndex - (totalComponents - 1);
-    }
+    let lastItemIndex = Math.ceil(visibleBottom / _estimateHeight) - 1;
+    lastItemIndex = Math.min(maxIndex, lastItemIndex + bufferSize);
 
     this._firstItemIndex = firstItemIndex;
     this._lastItemIndex = lastItemIndex;
@@ -75,8 +68,23 @@ export default class StaticRadar extends Radar {
   }
 
   get lastVisibleIndex() {
-    const lastVisibleIndex = Math.min(Math.ceil(this.visibleBottom / this._estimateHeight), this.totalItems - 1);
+    const lastVisibleIndex = Math.min(Math.ceil(this.visibleBottom / this._estimateHeight), this.totalItems) - 1;
 
     return this.firstItemIndex === NULL_INDEX ? NULL_INDEX : lastVisibleIndex;
+  }
+
+  get totalComponents() {
+    const {
+      _scrollContainerHeight,
+      _estimateHeight,
+      bufferSize,
+      totalItems
+    } = this;
+
+    // The total number of components is determined by the minimum number required to span the
+    // container plus its buffers. Combined with the above rendering strategy this is fairly
+    // performant, even if mean item size is above the minimum.
+    const calculatedComponents = Math.ceil(_scrollContainerHeight / _estimateHeight) + 1 + (bufferSize * 2);
+    return Math.min(totalItems, calculatedComponents);
   }
 }

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -107,13 +107,12 @@ export default class SkipList {
     const numLayers = layers.length;
 
     if (length === 0) {
-      return { index: 0, totalBefore: 0, totalAfter: 0 };
+      return { index: 0, totalBefore: 0 };
     }
 
     let i, layer, left, leftIndex, rightIndex;
     let index = 0;
     let totalBefore = 0;
-    let totalAfter = 0;
 
     targetValue = Math.min(total - 1, targetValue);
 
@@ -139,12 +138,10 @@ export default class SkipList {
 
     index = index / 2;
 
-    totalAfter = total - totalBefore;
-
     assert('index must be a number', typeof index === 'number');
     assert('index must be within bounds', index >= 0 && index < this.values.length);
 
-    return { index, totalBefore, totalAfter };
+    return { index, totalBefore };
   }
 
   set(index, value) {

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -32,7 +32,7 @@ const VerticalCollection = Component.extend({
 
   // –––––––––––––– Required Settings
 
-  minHeight: null,
+  estimateHeight: null,
 
   // usable via {{#vertical-collection <items-array>}}
   items: null,
@@ -82,7 +82,7 @@ const VerticalCollection = Component.extend({
   isEmpty: computed.empty('items'),
   shouldYieldToInverse: computed.and('isEmpty', 'supportsInverse'),
 
-  virtualComponents: computed('items.[]', 'minHeight', 'bufferSize', function() {
+  virtualComponents: computed('items.[]', 'estimateHeight', 'bufferSize', function() {
     const {
       _radar,
       _prevItemsLength,
@@ -90,7 +90,7 @@ const VerticalCollection = Component.extend({
       _prevLastKey
     } = this;
 
-    _radar.minHeight = this.get('minHeight');
+    _radar.estimateHeight = this.get('estimateHeight');
     _radar.bufferSize = this.get('bufferSize');
 
     const items = this.get('items');
@@ -177,7 +177,7 @@ const VerticalCollection = Component.extend({
 
   _initializeEventHandlers() {
     this._scrollHandler = ({ top }) => {
-      if (Math.abs(this._lastEarthquake - top) > this._radar._minHeight / 2) {
+      if (Math.abs(this._lastEarthquake - top) > this._radar._estimateHeight / 2) {
         this._radar.scheduleUpdate();
         this._lastEarthquake = top;
       }

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -58,7 +58,7 @@ const VerticalCollection = Component.extend({
    * how much extra room to keep visible and invisible on
    * either side of the viewport.
    */
-  bufferSize: 0,
+  bufferSize: 1,
 
   // –––––––––––––– Initial Scroll State
   /*

--- a/addon/styles/app.css
+++ b/addon/styles/app.css
@@ -10,6 +10,9 @@ occluded-content {
   display: block;
   position: relative;
   width: 100%;
+
+  /* prevents margin overflow on item container */
+  min-height: 0.001px;
 }
 
 table > occluded-content,

--- a/tests/acceptance/acceptance-tests/record-array-test.js
+++ b/tests/acceptance/acceptance-tests/record-array-test.js
@@ -14,9 +14,9 @@ if (VERSION.match(/1\.11\.\d+/) === null) {
 
     andThen(function() {
       return wait().then(() => {
-        assert.equal(find('number-slide').length, 21, 'correct number of items rendered');
+        assert.equal(find('number-slide').length, 15, 'correct number of items rendered');
         assert.equal(find('number-slide:first').text().replace(/\s/g, ''), '0(0)', 'correct first item rendered');
-        assert.equal(find('number-slide:last').text().replace(/\s/g, ''), '20(20)', 'correct last item rendered');
+        assert.equal(find('number-slide:last').text().replace(/\s/g, ''), '14(14)', 'correct last item rendered');
       });
     });
   });

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -1,6 +1,6 @@
 <div class="table-wrapper dark">
   {{#vertical-collection model
-    minHeight=50
+    estimateHeight=50
     bufferSize=5
 
     as |item index|}}

--- a/tests/dummy/app/routes/examples/dbmon/template.hbs
+++ b/tests/dummy/app/routes/examples/dbmon/template.hbs
@@ -11,7 +11,7 @@
                 tagName="tbody"
                 key="id"
 
-                minHeight=37
+                estimateHeight=37
                 staticHeight=true
                 bufferSize=5
 

--- a/tests/dummy/app/routes/examples/flexible-layout/template.hbs
+++ b/tests/dummy/app/routes/examples/flexible-layout/template.hbs
@@ -5,7 +5,7 @@
       {{!- BEGIN-SNIPPET flexible-layout-example }}
         <div class="table-wrapper dark">
           {{#vertical-collection model.numbers
-            minHeight=270
+            estimateHeight=270
             firstReached="loadAbove"
             lastReached="loadBelow"
             as |item index|

--- a/tests/dummy/app/routes/examples/infinite-scroll/controller.js
+++ b/tests/dummy/app/routes/examples/infinite-scroll/controller.js
@@ -31,7 +31,7 @@ export default Controller.extend({
       this.set('model.last', last + 20);
     },
 
-    setMinHeight() {
+    setEstimateHeight() {
       this.set('someProperty', 90);
     }
   }

--- a/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
@@ -5,7 +5,7 @@
       {{!- BEGIN-SNIPPET infinite-scroll-example }}
         <div class="table-wrapper dark">
           {{#vertical-collection model.numbers
-            minHeight=90
+            estimateHeight=90
             staticHeight=true
             bufferSize=5
 

--- a/tests/dummy/app/routes/examples/scrollable-body/template.hbs
+++ b/tests/dummy/app/routes/examples/scrollable-body/template.hbs
@@ -3,7 +3,7 @@
         <div class="col-sm-7">
           {{!- BEGIN-SNIPPET scrollable-body-example }}
             {{#vertical-collection model.numbers
-              minHeight=40
+              estimateHeight=40
               containerSelector="body"
               as |item index|
             }}

--- a/tests/dummy/app/routes/settings/snippets/defaults.js
+++ b/tests/dummy/app/routes/settings/snippets/defaults.js
@@ -19,7 +19,7 @@ export default
   // Can be an integer, but also attempts to work
   // with em, rem, px, and percentage values for things
   // like flex.
-  minHeight: null,
+  estimateHeight: null,
 
 // performance
 
@@ -45,7 +45,7 @@ export default
   // collection. Represents a static number of components
   // that will be added, such that:
   //
-  // numComponents === Math.ceil(containerHeight / minHeight) + (bufferSize * 2) + 1
+  // numComponents === Math.ceil(containerHeight / estimateHeight) + (bufferSize * 2) + 1
   bufferSize: 0,
 
 // actions

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -108,7 +108,7 @@ export function scenariosFor(items, options) {
 export const standardTemplate = hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      minHeight=(either-or minHeight 20)
+      estimateHeight=(either-or estimateHeight 20)
       staticHeight=staticHeight
       bufferSize=(either-or bufferSize 5)
 
@@ -123,7 +123,7 @@ export const standardTemplate = hbs`
       key=key
 
       as |item i|}}
-      <div style={{html-safe (join-strings "height:" (either-or itemHeight (either-or minHeight 20)) "px;")}}>
+      <div style={{html-safe (join-strings "height:" (either-or itemHeight (either-or estimateHeight 20)) "px;")}}>
         {{item.number}} {{i}}
       </div>
     {{/vertical-collection}}

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -110,7 +110,7 @@ export const standardTemplate = hbs`
     {{#vertical-collection ${'items'}
       estimateHeight=(either-or estimateHeight 20)
       staticHeight=staticHeight
-      bufferSize=(either-or bufferSize 5)
+      bufferSize=(either-or bufferSize 0)
 
       renderFromLast=renderFromLast
       idForFirstItem=idForFirstItem

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -57,7 +57,7 @@ testScenarios(
 testScenarios(
   'The collection renders correct number of components with bufferSize set',
   standardTemplate,
-  scenariosFor(getNumbers(0, 10), { minHeight: 200, bufferSize: 1 }),
+  scenariosFor(getNumbers(0, 10), { estimateHeight: 200, bufferSize: 1 }),
 
   function(assert) {
     assert.expect(1);
@@ -80,7 +80,7 @@ test('The collection renders with containerSelector set', function(assert) {
     <div>
       {{#vertical-collection ${'items'}
         containerSelector=".scrollable"
-        minHeight=20
+        estimateHeight=20
         staticHeight=true
         bufferSize=0
 
@@ -108,7 +108,7 @@ test('The collection renders in the correct initial position', function(assert) 
     <div>
       {{#vertical-collection ${'items'}
         containerSelector=".scrollable"
-        minHeight=20
+        estimateHeight=20
         staticHeight=true
         bufferSize=0
 
@@ -139,7 +139,7 @@ test('The collection renders in the correct initial position with dynamic height
     <div style="padding: 200px;">
       {{#vertical-collection ${'items'}
         containerSelector=".scrollable"
-        minHeight=20
+        estimateHeight=20
 
         as |item i|}}
         <vertical-item style="height: 28px">
@@ -167,7 +167,7 @@ test('The collection renders when yielded item has conditional', function(assert
   this.render(hbs`
     <div style="height: 500px; width: 500px;">
       {{#vertical-collection ${'items'}
-        minHeight=10
+        estimateHeight=10
         containerSelector="body"
         as |item|
       }}
@@ -192,7 +192,7 @@ test('The collection renders the initialRenderCount correctly', function(assert)
   this.render(hbs`
     <div style="height: 500px; width: 500px;" class="scrollable">
       {{#vertical-collection ${'items'}
-        minHeight=50
+        estimateHeight=50
         initialRenderCount=1
         as |item i|
       }}
@@ -222,7 +222,7 @@ test('The collection renders the initialRenderCount correctly if idForFirstItem 
   this.render(hbs`
     <div style="height: 500px; width: 500px;" class="scrollable">
       {{#vertical-collection ${'items'}
-        minHeight=50
+        estimateHeight=50
         initialRenderCount=1
         idForFirstItem="20"
         key="number"
@@ -254,7 +254,7 @@ test('The collection renders the initialRenderCount correctly if the count is mo
   this.render(hbs`
     <div style="height: 500px; width: 500px;" class="scrollable">
       {{#vertical-collection ${'items'}
-        minHeight=50
+        estimateHeight=50
         initialRenderCount=5
         as |item i|
       }}

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -60,12 +60,24 @@ testScenarios(
   scenariosFor(getNumbers(0, 10), { estimateHeight: 200, bufferSize: 1 }),
 
   function(assert) {
-    assert.expect(1);
+    assert.expect(3);
+
+    const scrollable = this.$('.scrollable');
 
     return wait().then(() => {
       // Should render 2 components to be able to cover the whole scroll space, and 1
-      // extra buffer component on either side
-      assert.equal(this.$('.scrollable').find('div').length, 4);
+      // extra buffer component on the bottom
+      assert.equal(scrollable.find('div').length, 2);
+      scrollable.scrollTop(200);
+      return wait();
+    }).then(() => {
+      // Should render a buffer on both sides
+      assert.equal(scrollable.find('div').length, 3);
+      scrollable.scrollTop(2000);
+      return wait();
+    }).then(() => {
+      // Back to 3 items because at the bottom
+      assert.equal(scrollable.find('div').length, 2);
     });
   }
 );
@@ -94,11 +106,11 @@ test('The collection renders with containerSelector set', function(assert) {
   `);
 
   return wait().then(() => {
-    assert.equal(this.$().find('vertical-item').length, 6);
+    assert.equal(this.$().find('vertical-item').length, 5);
   });
 });
 
-test('The collection renders in the correct initial position', function(assert) {
+test('The collection renders in the correct initial position when offset', function(assert) {
   assert.expect(3);
 
   this.set('items', getNumbers(0, 100));
@@ -124,8 +136,8 @@ test('The collection renders in the correct initial position', function(assert) 
   return wait().then(() => {
     let occludedBoundaries = this.$().find('occluded-content');
     assert.equal(occludedBoundaries.get(0).getAttribute('style'), 'height: 0px;', 'Occluded height above is 0');
-    assert.equal(occludedBoundaries.get(1).getAttribute('style'), 'height: 1880px;', 'Occluded height below is 20 * 94 items');
-    assert.equal(this.$().find('vertical-item').length, 6, 'We rendered 100/20 + 1 items');
+    assert.equal(occludedBoundaries.get(1).getAttribute('style'), 'height: 1940px;', 'Occluded height below is 20 * 94 items');
+    assert.equal(this.$().find('vertical-item').length, 3, 'We rendered 50/20 items');
   });
 });
 
@@ -140,6 +152,7 @@ test('The collection renders in the correct initial position with dynamic height
       {{#vertical-collection ${'items'}
         containerSelector=".scrollable"
         estimateHeight=20
+        bufferSize=0
 
         as |item i|}}
         <vertical-item style="height: 28px">
@@ -153,8 +166,8 @@ test('The collection renders in the correct initial position with dynamic height
   return wait().then(() => {
     let occludedBoundaries = this.$().find('occluded-content');
     assert.equal(occludedBoundaries.get(0).getAttribute('style'), 'height: 0px;', 'Occluded height above is 0');
-    assert.equal(occludedBoundaries.get(1).getAttribute('style'), 'height: 1880px;', 'Occluded height below is 20 * 94 items');
-    assert.equal(this.$().find('vertical-item').length, 6, 'We rendered 100/20 + 1 items');
+    assert.equal(occludedBoundaries.get(1).getAttribute('style'), 'height: 1940px;', 'Occluded height below is 20 * 94 items');
+    assert.equal(this.$().find('vertical-item').length, 3, 'We rendered 50/20 items');
   });
 });
 
@@ -241,9 +254,9 @@ test('The collection renders the initialRenderCount correctly if idForFirstItem 
   });
 
   return wait().then(() => {
-    assert.equal(this.$('vertical-item').length, 11, 'correctly updates the number of items rendered on second pass');
-    assert.equal(this.$('vertical-item:eq(0)').text().trim(), '20 20', 'correct first item rendered');
-    assert.equal(this.$('vertical-item:eq(10)').text().trim(), '30 30', 'correct last item rendered');
+    assert.equal(this.$('vertical-item').length, 12, 'correctly updates the number of items rendered on second pass');
+    assert.equal(this.$('vertical-item:eq(0)').text().trim(), '19 19', 'correct first item rendered');
+    assert.equal(this.$('vertical-item:eq(11)').text().trim(), '30 30', 'correct last item rendered');
   });
 });
 

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -23,7 +23,7 @@ test('The collection correctly remeasures items when scrolling down', function(a
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      minHeight=20
+      estimateHeight=20
 
       as |item|}}
       <div class="item" style="height: 20px;">
@@ -59,7 +59,7 @@ test('The collection correctly remeasures items when scrolling up', function(ass
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      minHeight=20
+      estimateHeight=20
 
       as |item|}}
       <div class="item" style="height: 20px;">
@@ -96,7 +96,7 @@ test('Can scroll correctly in dynamic list of items that has non-integer heights
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      minHeight=20
+      estimateHeight=20
 
       as |item i|}}
       <div style="height: 33.333px;">{{item.number}} {{i}}</div>
@@ -127,7 +127,7 @@ test('Can measure and affect correctly in list of items with non-integer heights
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      minHeight=20
+      estimateHeight=20
       key="@index"
       idForFirstItem="10"
       bufferSize=1
@@ -153,7 +153,7 @@ test('Measurements are correct after a prepend', function(assert) {
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      minHeight=20
+      estimateHeight=20
 
       as |item i|}}
       <div style="height: 30px;">{{item.number}} {{i}}</div>

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -24,6 +24,7 @@ test('The collection correctly remeasures items when scrolling down', function(a
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       estimateHeight=20
+      bufferSize=0
 
       as |item|}}
       <div class="item" style="height: 20px;">
@@ -60,6 +61,7 @@ test('The collection correctly remeasures items when scrolling up', function(ass
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       estimateHeight=20
+      bufferSize=0
 
       as |item|}}
       <div class="item" style="height: 20px;">
@@ -73,18 +75,18 @@ test('The collection correctly remeasures items when scrolling up', function(ass
   const itemContainer = this.$('vertical-collection');
 
   return wait().then(() => {
-    assert.equal(paddingAfter(itemContainer), 1780, 'itemContainer padding is correct on initial render');
-    scrollContainer.scrollTop(21);
+    assert.equal(paddingAfter(itemContainer), 1800, 'itemContainer padding is correct on initial render');
+    scrollContainer.scrollTop(20);
 
     return wait();
   }).then(() => {
-    assert.equal(paddingAfter(itemContainer), 1760, 'itemContainer padding is correct after scrolling down');
+    assert.equal(paddingAfter(itemContainer), 1780, 'itemContainer padding is correct after scrolling down');
     this.$('.item:last').height(50);
     scrollContainer.scrollTop(0);
 
     return wait();
   }).then(() => {
-    assert.equal(paddingAfter(itemContainer), 1810, 'itemContainer padding has the height of the modified last element');
+    assert.equal(paddingAfter(itemContainer), 1830, 'itemContainer padding has the height of the modified last element');
   });
 });
 
@@ -141,7 +143,7 @@ test('Can measure and affect correctly in list of items with non-integer heights
   const scrollable = this.$('.scrollable');
 
   return wait().then(() => {
-    assert.equal(scrollable.scrollTop(), 230, 'scrollTop set to correct value');
+    assert.equal(scrollable.scrollTop(), 210, 'scrollTop set to correct value');
   });
 });
 
@@ -154,6 +156,7 @@ test('Measurements are correct after a prepend', function(assert) {
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       estimateHeight=20
+      bufferSize=1
 
       as |item i|}}
       <div style="height: 30px;">{{item.number}} {{i}}</div>
@@ -168,8 +171,8 @@ test('Measurements are correct after a prepend', function(assert) {
     .then(() => prepend(this, getNumbers(-20, 20)))
     .then(wait)
     .then(() => {
-      assert.equal(scrollable.scrollTop(), 420, 'scrollTop set to correct value');
-      assert.equal(paddingBefore(itemContainer), 360, 'Occluded content has the correct height before');
-      assert.equal(paddingAfter(itemContainer), 260, 'Occluded content has the correct height after');
+      assert.equal(scrollable.scrollTop(), 410, 'scrollTop set to correct value');
+      assert.equal(paddingBefore(itemContainer), 380, 'Occluded content has the correct height before');
+      assert.equal(paddingAfter(itemContainer), 290, 'Occluded content has the correct height after');
     });
 });

--- a/tests/integration/modern-ember-test.js
+++ b/tests/integration/modern-ember-test.js
@@ -16,7 +16,7 @@ if (SUPPORTS_INVERSE_BLOCK) {
 
     this.render(hbs`
       {{#vertical-collection ${'items'}
-        minHeight=20
+        estimateHeight=20
         staticHeight=true
       }}
         {{else}}

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -272,7 +272,7 @@ test('Dynamic collection maintains state if the same list is passed in twice', f
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      minHeight=20
+      estimateHeight=20
 
       as |item i|}}
       <div style="height:40px;">

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -29,7 +29,7 @@ testScenarios(
 
     return wait().then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before prepend');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly before prepnd');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before prepnd');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct before prepend');
       assert.equal(containerHeight(itemContainer), 2000, 'itemContainer height is correct before prepend');
 
@@ -37,8 +37,8 @@ testScenarios(
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div:first').text().trim(), '-5 15', 'first item rendered correctly after prepend');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '15 35', 'last item rendered correctly after prepend');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '0 20', 'first item rendered correctly after prepend');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 29', 'last item rendered correctly after prepend');
       assert.equal(scrollContainer.scrollTop(), 400, 'scrollTop is correct after prepend');
       assert.equal(containerHeight(itemContainer), 2400, 'itemContainer height is correct after prepend');
     });
@@ -58,7 +58,7 @@ testScenarios(
 
     return wait().then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before append');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly before append');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before append');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct before append');
       assert.equal(containerHeight(itemContainer), 2000, 'itemContainer height is correct after append');
 
@@ -67,7 +67,7 @@ testScenarios(
       return wait();
     }).then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly after append');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly after append');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly after append');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct after append');
       assert.equal(containerHeight(itemContainer), 2400, 'itemContainer height is correct after append');
     });
@@ -77,28 +77,25 @@ testScenarios(
 testScenarios(
   'Collection prepends correctly if prepend would cause more VCs to be shown',
   standardTemplate,
-  scenariosFor(getNumbers(0, 20)),
+  scenariosFor(getNumbers(0, 10), { bufferSize: 5 }),
 
   function(assert) {
-    assert.expect(8);
+    assert.expect(6);
 
     const scrollContainer = this.$('.scrollable');
-    const itemContainer = this.$('vertical-collection');
 
     return wait().then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before prepend');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '19 19', 'last item rendered correctly before prepend');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before prepend');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct before prepend');
-      assert.equal(containerHeight(itemContainer), 400, 'itemContainer height is correct before prepend');
 
-      prepend(this, getNumbers(-20, 20));
+      prepend(this, getNumbers(-5, 5));
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div:first').text().trim(), '-5 15', 'first item rendered correctly after prepend');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '15 35', 'last item rendered correctly after prepend');
-      assert.equal(scrollContainer.scrollTop(), 400, 'scrollTop is correct after prepend');
-      assert.equal(containerHeight(itemContainer), 800, 'itemContainer height is correct after prepend');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '-5 0', 'first item rendered correctly after prepend');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 14', 'last item rendered correctly after prepend');
+      assert.equal(scrollContainer.scrollTop(), 100, 'scrollTop is correct after prepend');
     });
   }
 );
@@ -106,28 +103,25 @@ testScenarios(
 testScenarios(
   'Collection appends correctly if append would cause more VCs to be shown',
   standardTemplate,
-  scenariosFor(getNumbers(0, 10)),
+  scenariosFor(getNumbers(0, 5)),
 
   function(assert) {
-    assert.expect(8);
+    assert.expect(6);
 
     const scrollContainer = this.$('.scrollable');
-    const itemContainer = this.$('vertical-collection');
 
     return wait().then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before append');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before append');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '4 4', 'last item rendered correctly before append');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct before append');
-      assert.equal(containerHeight(itemContainer), 200, 'itemContainer height is correct before append');
 
-      append(this, getNumbers(10, 20));
+      append(this, getNumbers(5, 5));
 
       return wait();
     }).then(() => {
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly after append');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly after append');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly after append');
       assert.equal(scrollContainer.scrollTop(), 0, 'scrollTop is correct after append');
-      assert.equal(containerHeight(itemContainer), 600, 'itemContainer height is correct after append');
     });
   }
 );
@@ -135,7 +129,7 @@ testScenarios(
 testScenarios(
   'Collection can shrink number of items if would cause fewer VCs to be shown',
   standardTemplate,
-  scenariosFor(getNumbers(0, 100)),
+  scenariosFor(getNumbers(0, 10)),
 
   function(assert) {
     assert.expect(6);
@@ -143,17 +137,17 @@ testScenarios(
     const scrollContainer = this.$('.scrollable');
 
     return wait().then(() => {
-      assert.equal(scrollContainer.find('div').length, 21, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div').length, 10, 'correct number of VCs rendered before reset');
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before reset');
 
-      this.set('items', getNumbers(0, 10));
+      this.set('items', getNumbers(0, 5));
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div').length, 10, 'correct number of VCs rendered after reset');
+      assert.equal(scrollContainer.find('div').length, 5, 'correct number of VCs rendered after reset');
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly after reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly after reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '4 4', 'last item rendered correctly after reset');
     });
   }
 );
@@ -161,7 +155,7 @@ testScenarios(
 testScenarios(
   'Collection can shrink number of items if would cause fewer VCs to be shown and scroll would change',
   standardTemplate,
-  scenariosFor(getNumbers(0, 100)),
+  scenariosFor(getNumbers(0, 20)),
 
   function(assert) {
     assert.expect(6);
@@ -169,21 +163,21 @@ testScenarios(
     const scrollContainer = this.$('.scrollable');
 
     return wait().then(() => {
-      scrollContainer.scrollTop(1000);
+      scrollContainer.scrollTop(200);
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div').length, 21, 'correct number of VCs rendered before reset');
-      assert.equal(scrollContainer.find('div:first').text().trim(), '45 45', 'first item rendered correctly before reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '65 65', 'last item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div').length, 10, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '10 10', 'first item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '19 19', 'last item rendered correctly before reset');
 
-      this.set('items', getNumbers(0, 10));
+      this.set('items', getNumbers(0, 5));
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div').length, 10, 'correct number of VCs rendered after reset');
+      assert.equal(scrollContainer.find('div').length, 5, 'correct number of VCs rendered after reset');
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '4 4', 'last item rendered correctly before reset');
     });
   }
 );
@@ -191,7 +185,7 @@ testScenarios(
 testScenarios(
   'Collection can shrink number of items to empty collection',
   standardTemplate,
-  scenariosFor(getNumbers(0, 100)),
+  scenariosFor(getNumbers(0, 10)),
 
   function(assert) {
     assert.expect(4);
@@ -199,9 +193,9 @@ testScenarios(
     const scrollContainer = this.$('.scrollable');
 
     return wait().then(() => {
-      assert.equal(scrollContainer.find('div').length, 21, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div').length, 10, 'correct number of VCs rendered before reset');
       assert.equal(scrollContainer.find('div:first').text().trim(), '0 0', 'first item rendered correctly before reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '20 20', 'last item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '9 9', 'last item rendered correctly before reset');
 
       emptyArray(this);
 
@@ -215,7 +209,7 @@ testScenarios(
 testScenarios(
   'Collection can shrink number of items to empty collection (after scroll has changed)',
   standardTemplate,
-  scenariosFor(getNumbers(0, 100)),
+  scenariosFor(getNumbers(0, 20)),
 
   function(assert) {
     assert.expect(4);
@@ -223,13 +217,13 @@ testScenarios(
     const scrollContainer = this.$('.scrollable');
 
     return wait().then(() => {
-      scrollContainer.scrollTop(1000);
+      scrollContainer.scrollTop(200);
 
       return wait();
     }).then(() => {
-      assert.equal(scrollContainer.find('div').length, 21, 'correct number of VCs rendered before reset');
-      assert.equal(scrollContainer.find('div:first').text().trim(), '45 45', 'first item rendered correctly before reset');
-      assert.equal(scrollContainer.find('div:last').text().trim(), '65 65', 'last item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div').length, 10, 'correct number of VCs rendered before reset');
+      assert.equal(scrollContainer.find('div:first').text().trim(), '10 10', 'first item rendered correctly before reset');
+      assert.equal(scrollContainer.find('div:last').text().trim(), '19 19', 'last item rendered correctly before reset');
 
       emptyArray(this);
 
@@ -273,6 +267,7 @@ test('Dynamic collection maintains state if the same list is passed in twice', f
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
       estimateHeight=20
+      bufferSize=0
 
       as |item i|}}
       <div style="height:40px;">
@@ -287,7 +282,7 @@ test('Dynamic collection maintains state if the same list is passed in twice', f
 
   return wait().then(() => {
     // Occlude a single item
-    scrollContainer.scrollTop(140);
+    scrollContainer.scrollTop(40);
 
     return wait();
   }).then(() => {

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -244,7 +244,7 @@ testScenarios(
       {{#vertical-collection ${'items'}
         containerSelector=".scrollable"
         tagName="tbody"
-        minHeight=37
+        estimateHeight=37
         staticHeight=staticHeight
 
         as |item i|}}
@@ -292,7 +292,7 @@ test('Collection measures correctly when it\'s scroll parent has scrolled', func
   <div style="height: 200px; width: 200px;" class="scroll-parent scrollable">
     <div style="height: 400px; width: 100px;" class="scroll-child scrollable">
       {{#vertical-collection ${'items'}
-        minHeight=20
+        estimateHeight=20
 
         as |item i|}}
         <div style="height:20px;">
@@ -321,7 +321,7 @@ test('Can scroll to last item when actual item sizes are significantly larger th
   this.render(hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection ${'items'}
-      minHeight=10
+      estimateHeight=10
 
       as |item i|}}
       <div style="height: 100px;">{{item.number}} {{i}}</div>

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -79,9 +79,9 @@ testScenarios(
 
     this.on('firstVisibleChanged', (item, index) => {
       if (count === 0) {
-        assert.equal(index, 0, 'the first visible item should be item 0');
+        assert.equal(index, 0, 'the first visible item is correct');
       } else {
-        assert.equal(index, 10, 'after scroll the first visible item should be item 10');
+        assert.equal(index, 10, 'after scroll the first visible item is correct');
       }
       count++;
       called();
@@ -102,9 +102,9 @@ testScenarios(
 
     this.on('lastVisibleChanged', (item, index) => {
       if (count === 0) {
-        assert.equal(index, 10, 'the first last visible changed should be item 10');
+        assert.equal(index, 9, 'the first last visible changed is correct');
       } else {
-        assert.equal(index, 20, 'after scroll the last visible change should be item 20');
+        assert.equal(index, 19, 'after scroll the last visible change is correct');
       }
       count++;
       called();
@@ -124,7 +124,7 @@ testScenarios(
 
     this.on('firstReached', (item, index) => {
       if (index === 0) {
-        assert.ok(true, 'the firstReached item should be item 0');
+        assert.ok(true, 'the firstReached item is correct');
         called();
       }
     });
@@ -141,7 +141,7 @@ testScenarios(
 
     this.on('lastReached', (item, index) => {
       if (index === 49) {
-        assert.ok(true, 'the lastReached item should be item 49');
+        assert.ok(true, 'the lastReached item is correct');
         called();
       }
     });
@@ -153,14 +153,14 @@ testScenarios(
 testScenarios(
   'Sends the firstReached action after prepend',
   standardTemplate,
-  standardScenariosFor(getNumbers(0, 20), { firstReached: 'firstReached' }),
+  standardScenariosFor(getNumbers(0, 20), { firstReached: 'firstReached', bufferSize: 5 }),
 
   function(assert) {
     assert.expect(0);
     const called = assert.async(2);
 
     this.on('firstReached', ({ number }) => {
-      prepend(this, getNumbers(number - 5, 5));
+      prepend(this, getNumbers(number - 3, 5));
       called();
     });
   }
@@ -169,14 +169,14 @@ testScenarios(
 testScenarios(
   'Sends the lastReached action after append',
   standardTemplate,
-  standardScenariosFor(getNumbers(0, 10), { lastReached: 'lastReached' }),
+  standardScenariosFor(getNumbers(0, 10), { lastReached: 'lastReached', bufferSize: 5 }),
 
   function(assert) {
     assert.expect(0);
     const called = assert.async(2);
 
     this.on('lastReached', ({ number }) => {
-      append(this, getNumbers(number + 1, 8));
+      append(this, getNumbers(number + 1, 5));
       called();
     });
   }
@@ -246,6 +246,7 @@ testScenarios(
         tagName="tbody"
         estimateHeight=37
         staticHeight=staticHeight
+        bufferSize=0
 
         as |item i|}}
         <tr>
@@ -285,7 +286,7 @@ testScenarios(
 );
 
 test('Collection measures correctly when it\'s scroll parent has scrolled', function(assert) {
-  assert.expect(0);
+  assert.expect(1);
   this.set('items', Ember.A(getNumbers(0, 100)));
 
   this.render(hbs`
@@ -293,9 +294,10 @@ test('Collection measures correctly when it\'s scroll parent has scrolled', func
     <div style="height: 400px; width: 100px;" class="scroll-child scrollable">
       {{#vertical-collection ${'items'}
         estimateHeight=20
+        bufferSize=0
 
         as |item i|}}
-        <div style="height:20px;">
+        <div style="height:40px;">
           {{item.number}} {{i}}
         </div>
       {{/vertical-collection}}
@@ -308,8 +310,11 @@ test('Collection measures correctly when it\'s scroll parent has scrolled', func
 
   return wait().then(() => {
     scrollParent.scrollTop(200);
-    scrollChild.scrollTop(600);
-    // An assertion will be thrown if the scroll parent affects the measurement
+    scrollChild.scrollTop(400);
+
+    return wait();
+  }).then(() => {
+    assert.equal(scrollChild.find('div:first').html().trim(), '10 10', 'correct first item rendered');
   });
 });
 


### PR DESCRIPTION
Removes the minHeight constraint and replaces it with `estimateHeight`. Also makes the collection create VCs dynamically based on the size of the scrollContainer so the number of VCs will be minimized and able to adapt to a large number of items being under the `estimateHeight`.

Note: If there are a large number of items under the estimateHeight on initial render, they still won't span the scrollContainer immediately. This is kind of a catch-22 because in order to know how many VCs we need to render, we need to first render them and then measure them. We can attempt to progressively re-render until the scrollContainer is spanned, but for now I think the recommended solution would be to on average have item height be above the estimate, and if it can't be use larger buffers.