### PR TITLE
bugfix(max-height): Use computed style to determine if max-height exists

### DIFF
--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -203,7 +203,8 @@ export default class Radar {
       height: scrollContainerHeight
     } = scrollContainer.getBoundingClientRect();
 
-    const maxHeight = scrollContainer.style ? parseInt(scrollContainer.style.maxHeight || 0) : 0;
+    let maxHeight = scrollContainer instanceof Element ? parseInt(window.getComputedStyle(scrollContainer).maxHeight) : 0;
+    maxHeight = isNaN(maxHeight) ? 0 : maxHeight;
 
     this._estimateHeight = typeof estimateHeight === 'string' ? estimateElementHeight(itemContainer, estimateHeight) : estimateHeight;
     this._scrollTopOffset = roundTo(this._scrollTop + itemContainerTop - scrollContainerTop);

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -39,13 +39,17 @@ nav a {
 
 .table-wrapper, .scrollable {
   display: block;
-  height: 1000px;
-  max-height: 500px;
+  height: 500px;
   overflow: scroll;
   -webkit-overflow-scrolling: touch;
   overflow-scrolling: touch;
   position: relative;
   background: #fff;
+}
+
+.scrollable.with-max-height {
+  height: initial;
+  max-height: 200px;
 }
 
 .table-wrapper.dark, .bg-dark {

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -290,6 +290,33 @@ test('The collection renders the initialRenderCount correctly if the count is mo
   assert.equal(find('vertical-item').textContent.trim(), '0 0', 'correct first item rendered');
 });
 
+testScenarios(
+  'The collection renders based on max height of the scroll parent',
+  simpleScenariosFor(getNumbers(0, 10)),
+
+  hbs`
+    <div class="scrollable with-max-height">
+      <div>
+        {{#vertical-collection ${'items'}
+          containerSelector=".scrollable"
+          estimateHeight=20
+          staticHeight=true
+          bufferSize=0
+
+          as |item i|}}
+          <vertical-item style="height: 20px">
+            {{item.number}} {{i}}
+          </vertical-item>
+        {{/vertical-collection}}
+      </div>
+    </div>
+  `,
+
+  function(assert) {
+    assert.equal(findAll('vertical-item').length, 10);
+  }
+);
+
 /*
 test("The Collection Reveals it's children when `renderAllInitially` is true.", function(assert) {
   assert.expect(1);


### PR DESCRIPTION
Fixes the max height detection on scroll container. This means that if the scroll container has a max-height set, the collection will ignore the actual height and always render the max-height with the assumption that it must do so to fill out the container.