### PR TITLE
feat(recycling): Makes recycling optional

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -5,8 +5,8 @@ import roundTo from '../utils/round-to';
 import { stripInProduction } from 'vertical-collection/-debug/helpers';
 
 export default class DynamicRadar extends Radar {
-  constructor(parentToken, initialItems, initialRenderCount, startingIndex) {
-    super(parentToken, initialItems, initialRenderCount, startingIndex);
+  constructor(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle) {
+    super(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle);
 
     this._firstItemIndex = NULL_INDEX;
     this._lastItemIndex = NULL_INDEX;

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -2,8 +2,8 @@ import { default as Radar, NULL_INDEX } from './radar';
 import { stripInProduction } from 'vertical-collection/-debug/helpers';
 
 export default class StaticRadar extends Radar {
-  constructor(parentToken, initialItems, initialRenderCount, startingIndex) {
-    super(parentToken, initialItems, initialRenderCount, startingIndex);
+  constructor(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle) {
+    super(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle);
 
     this._firstItemIndex = NULL_INDEX;
     this._lastItemIndex = NULL_INDEX;

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -40,6 +40,8 @@ const VerticalCollection = Component.extend({
   // –––––––––––––– Optional Settings
   staticHeight: false,
 
+  shouldRecycle: true,
+
   /*
    * A selector string that will select the element from
    * which to calculate the viewable height and needed offsets.
@@ -213,14 +215,16 @@ const VerticalCollection = Component.extend({
     const RadarClass = this.staticHeight ? StaticRadar : DynamicRadar;
 
     const items = this.get('items') || [];
-    const initialRenderCount = this.get('initialRenderCount');
-    const renderFromLast = this.get('renderFromLast');
+
     const idForFirstItem = this.get('idForFirstItem');
+    const initialRenderCount = this.get('initialRenderCount');
     const key = this.get('key');
+    const renderFromLast = this.get('renderFromLast');
+    const shouldRecycle = this.get('shouldRecycle');
 
     const startingIndex = calculateStartingIndex(items, idForFirstItem, key, renderFromLast);
 
-    this._radar = new RadarClass(this.token, items, initialRenderCount, startingIndex);
+    this._radar = new RadarClass(this.token, items, initialRenderCount, startingIndex, shouldRecycle);
     this._radar.renderFromLast = renderFromLast;
 
     this.supportsInverse = SUPPORTS_INVERSE_BLOCK;

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -300,7 +300,7 @@ testScenarios(
         {{#vertical-collection ${'items'}
           containerSelector=".scrollable"
           estimateHeight=20
-          staticHeight=true
+          staticHeight=staticHeight
           bufferSize=0
 
           as |item i|}}

--- a/tests/integration/recycle-test.js
+++ b/tests/integration/recycle-test.js
@@ -1,0 +1,87 @@
+import { moduleForComponent } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import {
+  find,
+  findAll,
+  scrollTo
+} from 'ember-native-dom-helpers';
+
+import getNumbers from 'dummy/lib/get-numbers';
+
+import {
+  testScenarios,
+
+  simpleScenariosFor
+} from 'dummy/tests/helpers/test-scenarios';
+
+moduleForComponent('vertical-collection', 'Integration | Recycle Tests', {
+  integration: true
+});
+
+testScenarios(
+  'The collection does not recycle when shouldRecycle is set to false',
+  simpleScenariosFor(getNumbers(0, 20)),
+
+  hbs`
+    <div style="height: 200px" class="scrollable with-max-height">
+      <div>
+        {{#vertical-collection ${'items'}
+          containerSelector=".scrollable"
+          estimateHeight=20
+          staticHeight=staticHeight
+          shouldRecycle=false
+          bufferSize=0
+
+          as |item i|}}
+          <vertical-item style="height: 20px">
+            {{unbound item.number}} {{unbound i}}
+          </vertical-item>
+        {{/vertical-collection}}
+      </div>
+    </div>
+  `,
+
+  async function(assert) {
+    assert.expect(2);
+
+    assert.equal(findAll('vertical-item').length, 10);
+
+    await scrollTo('.scrollable', 0, 20);
+
+    assert.equal(find('vertical-item:last-of-type').textContent.trim(), '10 10', 'component was not recycled');
+  }
+);
+
+testScenarios(
+  'The collection does recycle when shouldRecycle is set to true',
+  simpleScenariosFor(getNumbers(0, 20)),
+
+  hbs`
+    <div style="height: 200px" class="scrollable">
+      <div>
+        {{#vertical-collection ${'items'}
+          containerSelector=".scrollable"
+          estimateHeight=20
+          staticHeight=staticHeight
+          shouldRecycle=true
+          bufferSize=0
+
+          as |item i|}}
+          <vertical-item style="height: 20px">
+            {{unbound item.number}} {{unbound i}}
+          </vertical-item>
+        {{/vertical-collection}}
+      </div>
+    </div>
+  `,
+
+  async function(assert) {
+    assert.expect(2);
+
+    assert.equal(findAll('vertical-item').length, 10);
+
+    await scrollTo('.scrollable', 0, 20);
+
+    assert.equal(find('vertical-item:last-of-type').textContent.trim(), '0 0', 'component was recycled');
+  }
+);


### PR DESCRIPTION
Adds the `shouldRecycle` option which, when false, turns off component recycling. This may make sense for certain use cases, but it should be noted that in early testing this strategy is a major perf hit.

With recycling:

![screen shot 2017-07-17 at 9 12 22 am](https://user-images.githubusercontent.com/685518/28280086-71ae290e-6ad7-11e7-8375-69e02242bae3.png)

Without recycling:

![screen shot 2017-07-17 at 9 12 04 am](https://user-images.githubusercontent.com/685518/28280096-7ee9987e-6ad7-11e7-9043-5548f335fe14.png)

![screen shot 2017-07-17 at 9 12 08 am](https://user-images.githubusercontent.com/685518/28280107-864633fc-6ad7-11e7-9a4e-4cc13a816652.png)
