### PR TITLE
chore(cleanup): clean up various parts of radar

### DIFF
--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -1,12 +1,12 @@
-import { default as Radar, NULL_INDEX } from './radar';
+import Radar from './radar';
 import { stripInProduction } from 'vertical-collection/-debug/helpers';
 
 export default class StaticRadar extends Radar {
   constructor(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle) {
     super(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle);
 
-    this._firstItemIndex = NULL_INDEX;
-    this._lastItemIndex = NULL_INDEX;
+    this._firstItemIndex = 0;
+    this._lastItemIndex = 0;
 
     stripInProduction(() => {
       Object.preventExtensions(this);
@@ -23,8 +23,8 @@ export default class StaticRadar extends Radar {
     } = this;
 
     if (totalItems === 0) {
-      this._firstItemIndex = NULL_INDEX;
-      this._lastItemIndex = NULL_INDEX;
+      this._firstItemIndex = 0;
+      this._lastItemIndex = -1;
 
       return;
     }
@@ -62,14 +62,10 @@ export default class StaticRadar extends Radar {
   }
 
   get firstVisibleIndex() {
-    const firstVisibleIndex = Math.ceil(this.visibleTop / this._estimateHeight);
-
-    return this.firstItemIndex === NULL_INDEX ? NULL_INDEX : firstVisibleIndex;
+    return Math.ceil(this.visibleTop / this._estimateHeight);
   }
 
   get lastVisibleIndex() {
-    const lastVisibleIndex = Math.min(Math.ceil(this.visibleBottom / this._estimateHeight), this.totalItems) - 1;
-
-    return this.firstItemIndex === NULL_INDEX ? NULL_INDEX : lastVisibleIndex;
+    return Math.min(Math.ceil(this.visibleBottom / this._estimateHeight), this.totalItems) - 1;
   }
 }

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -101,16 +101,17 @@ export default class SkipList {
   }
 
   find(targetValue) {
-    const { layers, total, length } = this;
+    const { layers, total, length, values } = this;
     const numLayers = layers.length;
 
     if (length === 0) {
-      return { index: 0, totalBefore: 0 };
+      return { index: 0, totalBefore: 0, totalAfter: 0 };
     }
 
     let i, layer, left, leftIndex, rightIndex;
     let index = 0;
     let totalBefore = 0;
+    let totalAfter = 0;
 
     targetValue = Math.min(total - 1, targetValue);
 
@@ -139,7 +140,9 @@ export default class SkipList {
     assert('index must be a number', typeof index === 'number');
     assert('index must be within bounds', index >= 0 && index < this.values.length);
 
-    return { index, totalBefore };
+    totalAfter = total - (totalBefore + values[index]);
+
+    return { index, totalBefore, totalAfter };
   }
 
   set(index, value) {

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -136,8 +136,8 @@ testScenarios(
     let occludedBoundaries = findAll('occluded-content');
 
     assert.equal(occludedBoundaries[0].getAttribute('style'), 'height: 0px;', 'Occluded height above is correct');
-    assert.equal(occludedBoundaries[1].getAttribute('style'), 'height: 140px;', 'Occluded height below is correct');
-    assert.equal(findAll('vertical-item').length, 3, 'Rendered correct number of items');
+    assert.equal(occludedBoundaries[1].getAttribute('style'), 'height: 100px;', 'Occluded height below is correct');
+    assert.equal(findAll('vertical-item').length, 5, 'Rendered correct number of items');
   }
 );
 
@@ -168,8 +168,8 @@ testScenarios(
     let occludedBoundaries = findAll('occluded-content');
 
     assert.equal(occludedBoundaries[0].getAttribute('style'), 'height: 0px;', 'Occluded height above is correct');
-    assert.equal(occludedBoundaries[1].getAttribute('style'), 'height: 140px;', 'Occluded height below is correct');
-    assert.equal(findAll('vertical-item').length, 3, 'Rendered correct number of items');
+    assert.equal(occludedBoundaries[1].getAttribute('style'), 'height: 100px;', 'Occluded height below is correct');
+    assert.equal(findAll('vertical-item').length, 5, 'Rendered correct number of items');
   }
 );
 
@@ -184,12 +184,14 @@ testScenarios(
         containerSelector="body"
         as |item|
       }}
-        Content
-        {{#if item.shouldRender}}
-          <section>
-            Conditional Content
-          </section>
-        {{/if}}
+        <div>
+          Content
+          {{#if item.shouldRender}}
+            <section>
+              Conditional Content
+            </section>
+          {{/if}}
+        </div>
       {{/vertical-collection}}
     </div>
   `,


### PR DESCRIPTION
Cleans up radar by:

* Removing NULL_INDEX and replacing it with a reset flag. It was essentially implicitly tracking resets, so an explicit flag makes this behavior much clearer.
* Making `visibleTop` always 0 or great, getting rid of `visibleMiddle` and using the skip list to find the barriers always. No more while loops iterating around to find boundaries.
