### PR TITLE
feature(a11y): Adds labels for occluded content and pagination

### DIFF
--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -68,4 +68,11 @@ export default class StaticRadar extends Radar {
   get lastVisibleIndex() {
     return Math.min(Math.ceil(this.visibleBottom / this._estimateHeight), this.totalItems) - 1;
   }
+
+  /*
+   * Public API to query for the offset of an item
+   */
+  getOffsetForIndex(index) {
+    return index * this._estimateHeight + 1;
+  }
 }

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -145,6 +145,38 @@ export default class SkipList {
     return { index, totalBefore, totalAfter };
   }
 
+  getOffset(targetIndex) {
+    const { layers, length, values } = this;
+    const numLayers = layers.length;
+
+    if (length === 0) {
+      return 0;
+    }
+
+    let index = 0;
+    let offset = 0;
+
+    for (let i = 0; i < numLayers - 1; i++) {
+      const layer = layers[i];
+
+      const leftIndex = index;
+      const rightIndex = index + 1;
+
+      if (targetIndex >= rightIndex * Math.pow(2, numLayers - i - 1)) {
+        offset = offset + layer[leftIndex];
+        index = rightIndex * 2;
+      } else {
+        index = leftIndex * 2;
+      }
+    }
+
+    if (index + 1 === targetIndex) {
+      offset += values[index];
+    }
+
+    return offset;
+  }
+
   set(index, value) {
     assert('value must be a number', typeof value === 'number');
     assert('index must be a number', typeof index === 'number');

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -10,7 +10,8 @@ const {
   ArrayProxy,
   RSVP: {
     Promise
-  }
+  },
+  merge
 } = Ember;
 
 const {
@@ -130,8 +131,8 @@ function generateScenario(name, defaultOptions, initializer) {
 
 function mergeScenarioGenerators(...scenarioGenerators) {
   return function(items, options) {
-    const scenariosToCombine = scenarioGenerators.map((generator) => generator(items, options));
-
-    return Ember.merge(...scenariosToCombine);
+    return scenarioGenerators.reduce((scenarios, generator) => {
+      return merge(scenarios, generator(items, options));
+    }, {});
   };
 }

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -318,28 +318,3 @@ testScenarios(
     assert.equal(findAll('vertical-item').length, 10);
   }
 );
-
-testScenarios(
-  'The collection renders all items when renderAll is set',
-  scenariosFor(getNumbers(0, 20), { renderAll: true }),
-  standardTemplate,
-
-  async function(assert) {
-    assert.equal(findAll('.vertical-item').length, 20, 'correct number of items rendered');
-  }
-);
-
-testScenarios(
-  'The collection can switch on renderAll after being rendered',
-  scenariosFor(getNumbers(0, 20)),
-  standardTemplate,
-
-  async function(assert) {
-    assert.equal(findAll('.vertical-item').length, 10, 'correct number of items rendered before');
-
-    this.set('renderAll', true);
-    await waitForRender();
-
-    assert.equal(findAll('.vertical-item').length, 20, 'correct number of items rendered before');
-  }
-);


### PR DESCRIPTION
Adds labels in the `occluded-content` field which display how many items are above and below the rendered area, as well as pagination which will move the user forward/backward to the next/previous set of items when `occluded-content` is clicked. We will likely need to add ARIA roles or something to make it clear that `occluded-content` is clickable and meant for navigation.