### PR TITLE
bugfix(css): Makes a11y text invisible and margin fix

### DIFF
--- a/addon/styles/app.css
+++ b/addon/styles/app.css
@@ -12,7 +12,10 @@ occluded-content {
   width: 100%;
 
   /* prevents margin overflow on item container */
-  min-height: 0.001px;
+  min-height: 0.01px;
+
+  /* hides text visually while still being readable by screen readers */
+  color: rgba(0,0,0,0);
 }
 
 table > occluded-content,


### PR DESCRIPTION
Two fixes:

* `min-height` is used to prevent margin collapsing, but production builds will clear out the current value because it's too small.
* occluded a11y content can be visible if the user scrolls fast enough, this makes the text color transparent so it can still be read by screen readers but will be invisible otherwise.