### PR TITLE
perf(pooling): Reverts to maintaining a stable pool size

### DIFF
--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -260,7 +260,7 @@ export default class Radar {
       renderedLastItemIndex,
       renderedTotalBefore,
       renderedTotalAfter,
-      totalComponents
+      totalRendered
     } = this;
 
     // Add components to be recycled to the pool
@@ -292,7 +292,7 @@ export default class Radar {
     let lastIndexInList = orderedComponents[orderedComponents.length - 1] ? orderedComponents[orderedComponents.length - 1].index : renderedFirstItemIndex - 1;
 
     // Append as many items as needed to the rendered components
-    while (orderedComponents.length < totalComponents && lastIndexInList < renderedLastItemIndex) {
+    while (orderedComponents.length < totalRendered && lastIndexInList < renderedLastItemIndex) {
       let component;
 
       if (shouldRecycle === true) {
@@ -310,7 +310,7 @@ export default class Radar {
     }
 
     // Prepend as many items as needed to the rendered components
-    while (orderedComponents.length < totalComponents && firstIndexInList > renderedFirstItemIndex) {
+    while (orderedComponents.length < totalRendered && firstIndexInList > renderedFirstItemIndex) {
       let component;
 
       if (shouldRecycle === true) {
@@ -457,11 +457,11 @@ export default class Radar {
     const {
       bufferSize,
       renderedFirstItemIndex,
-      totalComponents
+      totalRendered
     } = this;
 
     if (renderedFirstItemIndex !== 0) {
-      const newFirstItemIndex = Math.max(renderedFirstItemIndex - totalComponents + bufferSize, 0);
+      const newFirstItemIndex = Math.max(renderedFirstItemIndex - totalRendered + bufferSize, 0);
       const offset = this.getOffsetForIndex(newFirstItemIndex);
 
       this.scrollContainer.scrollTop = offset + this._scrollTopOffset;
@@ -472,12 +472,12 @@ export default class Radar {
     const {
       bufferSize,
       renderedLastItemIndex,
-      totalComponents,
+      totalRendered,
       totalItems
     } = this;
 
     if (renderedLastItemIndex !== totalItems - 1) {
-      const newFirstItemIndex = Math.min(renderedLastItemIndex + bufferSize + 1, totalItems - totalComponents);
+      const newFirstItemIndex = Math.min(renderedLastItemIndex + bufferSize + 1, totalItems - totalRendered);
       const offset = this.getOffsetForIndex(newFirstItemIndex);
 
       this.scrollContainer.scrollTop = offset + this._scrollTopOffset;
@@ -502,8 +502,12 @@ export default class Radar {
     return this.renderAll === true ? 0 : this.totalAfter;
   }
 
+  get totalRendered() {
+    return this.renderAll === true ? this.totalItems : Math.min(this.totalItems, this.totalComponents);
+  }
+
   get totalComponents() {
-    return Math.min(this.totalItems, (this.renderedLastItemIndex - this.renderedFirstItemIndex) + 1);
+    return Math.ceil(this._scrollContainerHeight / this._estimateHeight) + (2 * this.bufferSize);
   }
 
   /*
@@ -521,6 +525,10 @@ export default class Radar {
    */
   get visibleTop() {
     return Math.max(this._scrollTop - this._scrollTopOffset + this._prependOffset, 0);
+  }
+
+  get visibleMiddle() {
+    return this.visibleTop + (this._scrollContainerHeight / 2);
   }
 
   get visibleBottom() {

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -15,10 +15,9 @@ export default class StaticRadar extends Radar {
 
   _updateIndexes() {
     const {
-      bufferSize,
       totalItems,
-      visibleTop,
-      visibleBottom,
+      totalComponents,
+      visibleMiddle,
       _estimateHeight
     } = this;
 
@@ -31,11 +30,20 @@ export default class StaticRadar extends Radar {
 
     const maxIndex = totalItems - 1;
 
-    let firstItemIndex = Math.floor(visibleTop / _estimateHeight);
-    firstItemIndex = Math.max(0, firstItemIndex - bufferSize);
+    const middleItemIndex = Math.floor(visibleMiddle / _estimateHeight);
 
-    let lastItemIndex = Math.ceil(visibleBottom / _estimateHeight) - 1;
-    lastItemIndex = Math.min(maxIndex, lastItemIndex + bufferSize);
+    let firstItemIndex = middleItemIndex - Math.floor(totalComponents / 2);
+    let lastItemIndex = middleItemIndex + Math.ceil(totalComponents / 2) - 1;
+
+    if (firstItemIndex < 0) {
+      firstItemIndex = 0;
+      lastItemIndex = Math.min(totalComponents - 1, maxIndex);
+    }
+
+    if (lastItemIndex > maxIndex) {
+      lastItemIndex = maxIndex;
+      firstItemIndex = Math.max(maxIndex - (totalComponents - 1), 0);
+    }
 
     this._firstItemIndex = firstItemIndex;
     this._lastItemIndex = lastItemIndex;

--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ module.exports = {
   treeForApp: function() {
     var tree = this._super.treeForApp.apply(this, arguments);
 
-    if (/production/.test(this._env) || /test/.test(this._env)) {
+    if (isProductionEnv()) {
       tree = new Funnel(tree, { exclude: [ /initializers/ ] });
     }
 

--- a/tests/acceptance/acceptance-tests/record-array-test.js
+++ b/tests/acceptance/acceptance-tests/record-array-test.js
@@ -16,8 +16,8 @@ if (VERSION.match(/1\.11\.\d+/) === null) {
 
     await waitForRender();
 
-    assert.equal(findAll('number-slide').length, 15, 'correct number of items rendered');
+    assert.equal(findAll('number-slide').length, 20, 'correct number of items rendered');
     assert.equal(find('number-slide:first-of-type').textContent.replace(/\s/g, ''), '0(0)', 'correct first item rendered');
-    assert.equal(find('number-slide:last-of-type').textContent.replace(/\s/g, ''), '14(14)', 'correct last item rendered');
+    assert.equal(find('number-slide:last-of-type').textContent.replace(/\s/g, ''), '19(19)', 'correct last item rendered');
   });
 }

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -64,19 +64,16 @@ testScenarios(
   async function(assert) {
     assert.expect(3);
 
-    // Should render 2 components to be able to cover the whole scroll space, and 1
-    // extra buffer component on the bottom
-    assert.equal(findAll('.vertical-item').length, 2);
+    // Should always render 3 components, one to span the space and two buffers
+    assert.equal(findAll('.vertical-item').length, 3);
 
     await scrollTo('.scrollable', 0, 200);
 
-    // Should render a buffer on both sides
     assert.equal(findAll('.vertical-item').length, 3);
 
     await scrollTo('.scrollable', 0, 2000);
 
-    // Back to 3 items because at the bottom
-    assert.equal(findAll('.vertical-item').length, 2);
+    assert.equal(findAll('.vertical-item').length, 3);
   }
 );
 
@@ -343,7 +340,7 @@ testScenarios(
   async function(assert) {
     assert.expect(2);
 
-    assert.equal(findAll('vertical-item').length, 7, 'Rendered correct number of items');
+    assert.equal(findAll('vertical-item').length, 9, 'Rendered correct number of items');
 
     await scrollTo('.scrollable', 0, 500);
 

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -106,10 +106,10 @@ testScenarios(
 
     await waitForRender();
 
-    assert.equal(find('.scrollable').scrollTop, 400, 'scrollTop set to correct value');
+    assert.equal(find('.scrollable').scrollTop, 420, 'scrollTop set to correct value');
 
     const itemContainer = find('vertical-collection');
-    assert.equal(paddingBefore(itemContainer), 400, 'Occluded content has the correct height before');
-    assert.equal(paddingAfter(itemContainer), 290, 'Occluded content has the correct height after');
+    assert.equal(paddingBefore(itemContainer), 360, 'Occluded content has the correct height before');
+    assert.equal(paddingAfter(itemContainer), 260, 'Occluded content has the correct height after');
   }
 );

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -214,7 +214,7 @@ testScenarios(
 
 testScenarios(
   'Dynamic collection maintains state if the same list is passed in twice',
-  dynamicSimpleScenarioFor(getNumbers(0, 10), { itemHeight: 40 }),
+  dynamicSimpleScenarioFor(getNumbers(0, 20), { itemHeight: 40 }),
   standardTemplate,
 
   async function(assert) {
@@ -222,7 +222,8 @@ testScenarios(
 
     const itemContainer = find('vertical-collection');
 
-    await scrollTo('.scrollable', 0, 40);
+    // Occlude a single item,
+    await scrollTo('.scrollable', 0, 140);
 
     assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '1 1', 'first item rendered correctly after initial scroll set');
     assert.equal(paddingBefore(itemContainer), 40, 'itemContainer padding correct before same items set');

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -170,7 +170,7 @@ testScenarios(
     const called = assert.async(2);
 
     this.on('lastReached', ({ number }) => {
-      append(this, getNumbers(number + 1, 5));
+      append(this, getNumbers(number + 1, 6));
       called();
     });
 
@@ -334,7 +334,7 @@ testScenarios(
     const called = assert.async(2);
 
     this.on('lastReached', ({ number }) => {
-      append(this, getNumbers(number + 1, 5));
+      append(this, getNumbers(number + 1, 6));
       called();
     });
 
@@ -451,7 +451,7 @@ testScenarios(
     await scrollTo('.scroll-parent', 0, 200);
     await scrollTo('.scroll-child', 0, 400);
 
-    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '10 10', 'correct first item rendered');
+    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '5 5', 'correct first item rendered');
   }
 );
 


### PR DESCRIPTION
Dynamic pool size is nice, especially if users regularly have items under the `estimateHeight`, but the perf hit was pretty large. This reverts to the previous behavior with a stable component pool size. If users need more components to render, they can use a larger `bufferSize`.