### PR TITLE
bugfix(skip-list): Fix skip-list reset and measurement behavior

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -27,6 +27,17 @@ export default class DynamicRadar extends Radar {
     this.skipList = null;
   }
 
+  _updateConstants() {
+    super._updateConstants();
+
+    // Create the SkipList only after the estimateHeight has been calculated the first time
+    if (this.skipList === null) {
+      this.skipList = new SkipList(this.totalItems, this._estimateHeight);
+    } else {
+      this.skipList.defaultValue = this._estimateHeight;
+    }
+  }
+
   _updateIndexes() {
     const {
       skipList,
@@ -198,7 +209,9 @@ export default class DynamicRadar extends Radar {
   reset() {
     super.reset();
 
-    this.skipList = new SkipList(this.totalItems, this.estimateHeight);
+    if (this.skipList !== null) {
+      this.skipList.reset(this.totalItems);
+    }
   }
 
   /*

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -37,6 +37,14 @@ function fill(array, value, start = 0, end = array.length) {
   }
 }
 
+function subarray(array, start, end) {
+  if (typeof array.subarray === 'function') {
+    return array.subarray(start, end);
+  } else {
+    return array.slice(start, end);
+  }
+}
+
 export default class SkipList {
   constructor(length, defaultValue) {
     const values = new Float32Array(new ArrayBuffer(length * 4));
@@ -64,8 +72,7 @@ export default class SkipList {
 
       layer = new Float32Array(new ArrayBuffer(length * 4));
 
-      // TODO add explicit test
-      if (defaultValue) {
+      if (defaultValue !== undefined) {
         // If given a default value we assume that we can fill each
         // layer of the skip list with the previous layer's value * 2.
         // This allows us to use the `fill` method on Typed arrays, which
@@ -239,5 +246,34 @@ export default class SkipList {
 
     this.length = newLength;
     this._initializeLayers(newValues);
+  }
+
+  reset(newLength) {
+    const {
+      values: oldValues,
+      length: oldLength,
+      defaultValue
+    } = this;
+
+    if (oldLength === newLength) {
+      return;
+    }
+
+    const newValues = new Float32Array(new ArrayBuffer(newLength * 4));
+
+    if (oldLength < newLength) {
+      newValues.set(oldValues);
+      fill(newValues, defaultValue, oldLength);
+    } else {
+      newValues.set(subarray(oldValues, 0, newLength));
+    }
+
+    this.length = newLength;
+
+    if (oldLength === 0) {
+      this._initializeLayers(newValues, defaultValue);
+    } else {
+      this._initializeLayers(newValues);
+    }
   }
 }

--- a/addon/-private/utils/element/estimate-element-height.js
+++ b/addon/-private/utils/element/estimate-element-height.js
@@ -5,21 +5,20 @@ export default function estimateElementHeight(element, fallbackHeight) {
   assert(`You called estimateElementHeight without an element`, element);
 
   if (fallbackHeight.indexOf('%') !== -1) {
-    let parentHeight = element.parentNode.innerHeight;
+    let parentHeight = element.getBoundingClientRect().height;
     let per = parseFloat(fallbackHeight);
 
-    return Math.max((per * parentHeight).toFixed(0), 1);
+    return Math.max(per * parentHeight / 100, 1);
+  }
+
+  if (fallbackHeight.indexOf('em') !== -1) {
+    const fontSizeElement = fallbackHeight.indexOf('rem') !== -1 ? document.body : element;
+    const fontSize = window.getComputedStyle(fontSizeElement).getPropertyValue('font-size');
+    const estimateHeight = parseFloat(fallbackHeight) * parseFloat(fontSize);
+
+    return Math.max(estimateHeight, 1);
   }
 
   // px or no units
-  if (fallbackHeight.indexOf('em') === -1) {
-    fallbackHeight = parseInt(fallbackHeight, 10);
-
-    return Math.max(fallbackHeight, 1);
-  }
-
-  const fontSize = window.getComputedStyle(element).getPropertyValue('font-size');
-  fallbackHeight = parseFloat(fallbackHeight) * parseFloat(fontSize);
-
-  return Math.max(fallbackHeight, 1);
+  return Math.max(parseInt(fallbackHeight, 10), 1);
 }

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -57,6 +57,106 @@ testScenarios(
 );
 
 testScenarios(
+  'The collection renders correctly when em height is used',
+  scenariosFor(getNumbers(0, 10)),
+
+  hbs`
+    <div style="height: 100px; font-size: 10px;" class="scrollable">
+      {{#vertical-collection ${'items'}
+        estimateHeight="2em"
+        staticHeight=staticHeight
+        bufferSize=0
+
+        as |item i|}}
+        <vertical-item style="height: 2em">
+          {{item.number}} {{i}}
+        </vertical-item>
+      {{/vertical-collection}}
+    </div>
+  `,
+
+  async function(assert) {
+    assert.expect(1);
+    assert.equal(findAll('vertical-item').length, 5);
+  }
+);
+
+testScenarios(
+  'The collection renders correctly when rem height is used',
+  scenariosFor(getNumbers(0, 10)),
+
+  hbs`
+    <div style="height: 100px; font-size: 10px;" class="scrollable">
+      {{#vertical-collection ${'items'}
+        estimateHeight="2rem"
+        staticHeight=staticHeight
+        bufferSize=0
+
+        as |item i|}}
+        <vertical-item style="height: 2rem">
+          {{item.number}} {{i}}
+        </vertical-item>
+      {{/vertical-collection}}
+    </div>
+  `,
+
+  async function(assert) {
+    assert.expect(1);
+    assert.equal(findAll('vertical-item').length, 4);
+  }
+);
+
+testScenarios(
+  'The collection renders correctly when percent height is used',
+  scenariosFor(getNumbers(0, 10)),
+
+  hbs`
+    <div style="height: 100px;" class="scrollable">
+      {{#vertical-collection ${'items'}
+        estimateHeight="66%"
+        staticHeight=staticHeight
+        bufferSize=0
+
+        as |item i|}}
+        <vertical-item style="height: 66%">
+          {{item.number}} {{i}}
+        </vertical-item>
+      {{/vertical-collection}}
+    </div>
+  `,
+
+  async function(assert) {
+    assert.expect(1);
+    assert.equal(findAll('vertical-item').length, 2);
+  }
+);
+
+testScenarios(
+  'The collection renders correctly when em height is used',
+  scenariosFor(getNumbers(0, 10)),
+
+  hbs`
+    <div style="height: 100px; font-size: 10px;" class="scrollable">
+      {{#vertical-collection ${'items'}
+        estimateHeight="2em"
+        staticHeight=staticHeight
+        bufferSize=0
+
+        as |item i|}}
+        <vertical-item style="height: 2em">
+          {{item.number}} {{i}}
+        </vertical-item>
+      {{/vertical-collection}}
+    </div>
+  `,
+
+  async function(assert) {
+    assert.expect(1);
+    assert.equal(findAll('vertical-item').length, 5);
+  }
+);
+
+testScenarios(
   'The collection renders correct number of components with bufferSize set',
   scenariosFor(getNumbers(0, 10), { estimateHeight: 200, bufferSize: 1 }),
   standardTemplate,

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -8,7 +8,7 @@ import waitForRender from 'dummy/tests/helpers/wait-for-render';
 import getNumbers from 'dummy/lib/get-numbers';
 
 import { paddingBefore, paddingAfter } from 'dummy/tests/helpers/measurement';
-import { prepend } from 'dummy/tests/helpers/array';
+import { prepend, replaceArray } from 'dummy/tests/helpers/array';
 
 import {
   testScenarios,
@@ -111,5 +111,29 @@ testScenarios(
     const itemContainer = find('vertical-collection');
     assert.equal(paddingBefore(itemContainer), 360, 'Occluded content has the correct height before');
     assert.equal(paddingAfter(itemContainer), 260, 'Occluded content has the correct height after');
+  }
+);
+
+testScenarios(
+  'Measurements are correct after a reset',
+  dynamicSimpleScenarioFor(getNumbers(0, 20), { itemHeight: 30 }),
+  standardTemplate,
+
+  async function(assert) {
+    assert.expect(6);
+
+    await scrollTo('.scrollable', 0, 300);
+
+    assert.equal(find('.scrollable').scrollTop, 300, 'scrollTop set to correct value');
+    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '10 10', 'the first rendered item is correct');
+    assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '19 19', 'the last rendered item is correct');
+
+    replaceArray(this, getNumbers(20, 20));
+
+    await waitForRender();
+
+    assert.equal(find('.scrollable').scrollTop, 300, 'scrollTop set to correct value');
+    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '30 10', 'the first rendered item is correct');
+    assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '39 19', 'the last rendered item is correct');
   }
 );


### PR DESCRIPTION
* Makes sure that the SkipList gets the correct estimate height
* Keeps measurement information when the SkipList is reset