### PR TITLE
bugfix(mutation): Handle scenario where items change position

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -127,7 +127,7 @@ const VerticalCollection = Component.extend({
       _radar.prepend(lenDiff);
     } else if (isAppend(lenDiff, items, key, _prevFirstKey, _prevLastKey) === true) {
       _radar.append(lenDiff);
-    } else if (isSameArray(lenDiff, items, key, _prevFirstKey, _prevLastKey) === false) {
+    } else {
       _radar.reset();
     }
 
@@ -309,19 +309,6 @@ function isAppend(lenDiff, newItems, key, oldFirstKey, oldLastKey) {
 
   const newFirstKey = keyForItem(objectAt(newItems, 0), key, 0);
   const newLastKey = keyForItem(objectAt(newItems, newItemsLength - lenDiff - 1), key, newItemsLength - lenDiff - 1);
-
-  return oldFirstKey === newFirstKey && oldLastKey === newLastKey;
-}
-
-function isSameArray(lenDiff, newItems, key, oldFirstKey, oldLastKey) {
-  const newItemsLength = get(newItems, 'length');
-
-  if (lenDiff !== 0 || newItemsLength === 0) {
-    return false;
-  }
-
-  const newFirstKey = keyForItem(objectAt(newItems, 0), key, 0);
-  const newLastKey = keyForItem(objectAt(newItems, newItemsLength - 1), key, newItemsLength - 1);
 
   return oldFirstKey === newFirstKey && oldLastKey === newLastKey;
 }

--- a/tests/helpers/array.js
+++ b/tests/helpers/array.js
@@ -55,3 +55,29 @@ export function replaceArray(context, items) {
 
   return waitForRender();
 }
+
+export function move(context, sourceItemIdx, destItemIdx) {
+  const items = context.get('items');
+  let destItem, sourceItem;
+
+  if (items.objectAt && items.removeObject && items.insertAt) {
+    // Ember Array
+    destItem = items.objectAt(destItemIdx);
+    sourceItem = items.objectAt(sourceItemIdx);
+    items.removeObject(sourceItem);
+    destItemIdx = items.indexOf(destItem) + 1;
+    items.insertAt(destItemIdx, sourceItem);
+  } else {
+    // native array
+    destItem = items[destItemIdx];
+    sourceItem = items[sourceItemIdx];
+    items.splice(sourceItemIdx, 1);
+    destItemIdx = items.indexOf(destItem) + 1;
+    items.splice(destItemIdx, 0, sourceItem);
+    // if we are not using Ember Arrays we need to set `items` to a new array
+    // instance to trigger a recompute on `virtualComponents`
+    context.set('items', [].concat(items));
+  }
+
+  return waitForRender();
+}

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -13,7 +13,7 @@ import {
   standardTemplate
 } from 'dummy/tests/helpers/test-scenarios';
 
-import { prepend, append, emptyArray, replaceArray } from 'dummy/tests/helpers/array';
+import { prepend, append, emptyArray, replaceArray, move } from 'dummy/tests/helpers/array';
 import { paddingBefore, containerHeight } from 'dummy/tests/helpers/measurement';
 
 moduleForComponent('vertical-collection', 'Integration | Mutation Tests', {
@@ -232,5 +232,28 @@ testScenarios(
 
     assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '1 1', 'first item rendered correctly after same items set');
     assert.equal(paddingBefore(itemContainer), 40, 'itemContainer padding correct after same items set');
+  }
+);
+
+testScenarios(
+  'Collection reorders correctly',
+  scenariosFor(getNumbers(0, 5)),
+  standardTemplate,
+
+  async function(assert) {
+    assert.expect(8);
+
+    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '0 0', 'first item rendered correctly before move');
+    assert.equal(find('.vertical-item:nth-of-type(2)').textContent.trim(), '1 1', 'second item starts in second');
+    assert.equal(find('.vertical-item:nth-of-type(4)').textContent.trim(), '3 3', 'foruth item starts in fourth');
+    assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '4 4', 'last item rendered correctly before move');
+
+    // move second object to the second last position
+    await move(this, 1, 3);
+
+    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '0 0', 'first item rendered correctly after move');
+    assert.equal(find('.vertical-item:nth-of-type(2)').textContent.trim(), '2 1', 'third item drops to second');
+    assert.equal(find('.vertical-item:nth-of-type(4)').textContent.trim(), '1 3', 'second item is now in fourth position');
+    assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '4 4', 'last item rendered correctly before move');
   }
 );


### PR DESCRIPTION
If you had a list of items `[1, 2, 3, 4, 5]` and it was changed to `[1,
4, 3, 2, 5]`, `vertical-collection` would continue to render the items
in their original position.  

This fixes the bug as discussed with @pzuraq on the Ember Slack.