### PR TITLE
Add 0 checking for visible top & container height

### DIFF
--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -534,14 +534,10 @@ export default class Radar {
   }
 
   get visibleBottom() {
-    // This is the case where the container of this vertical collection could have height 0px at
+    // There is a case where the container of this vertical collection could have height 0px at
     // initial render step but will be updated later. We want to return visibleBottom to be 0 rather
     // than -1.
-    if (this.visibleTop == 0 && this._scrollContainerHeight == 0) {
-      return 0;
-    }
-
-    return this.visibleTop + this._scrollContainerHeight - 1;
+    return Math.max(this.visibleTop + this._scrollContainerHeight - 1, 0);
   }
 
   get totalItems() {

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -534,6 +534,13 @@ export default class Radar {
   }
 
   get visibleBottom() {
+    // This is the case where the container of this vertical collection could have height 0 at
+    // initial render step but will be updated later. We want to return visibleBottom to be 0 rather
+    // than -1.
+    if (this.visibleTop == 0 && this._scrollContainerHeight == 0) {
+      return 0;
+    }
+
     return this.visibleTop + this._scrollContainerHeight - 1;
   }
 

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -534,7 +534,7 @@ export default class Radar {
   }
 
   get visibleBottom() {
-    // There is a case where the container of this vertical collection could have height 0px at
+    // There is a case where the container of this vertical collection could have height 0 at
     // initial render step but will be updated later. We want to return visibleBottom to be 0 rather
     // than -1.
     return Math.max(this.visibleTop + this._scrollContainerHeight - 1, 0);

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -534,7 +534,7 @@ export default class Radar {
   }
 
   get visibleBottom() {
-    // This is the case where the container of this vertical collection could have height 0 at
+    // This is the case where the container of this vertical collection could have height 0px at
     // initial render step but will be updated later. We want to return visibleBottom to be 0 rather
     // than -1.
     if (this.visibleTop == 0 && this._scrollContainerHeight == 0) {


### PR DESCRIPTION
I have an issue in VC usage that the container height is 0 at the beginning (because of height 100%) but will be updated later on. When the container height is 0, both `visibleTop` and `_scrollContainerHeight` are 0 and hence `visibleBottom` is -1. This crashes the app because the skip list expects item index to be non-negative. 

The fix is to set `visibleBottom` to be 0 when both `visibleTop` and `_scrollContainerHeight` are 0.

@pzuraq @runspired 

