### PR TITLE
[Perf] (WIP): Replace Skip List by Red Black Tree

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -1,7 +1,7 @@
 import Radar from './radar';
-import SkipList from '../skip-list';
-// import SkipList from '../rb-tree/rb-tree-wrapper';
-import RbTreeWrapper from '../rb-tree/rb-tree-wrapper';
+// import SkipList from '../skip-list';
+import SkipList from '../rb-tree/rb-tree-wrapper';
+// import RbTreeWrapper from '../rb-tree/rb-tree-wrapper';
 import roundTo from '../utils/round-to';
 
 import { stripInProduction } from 'vertical-collection/-debug/helpers';
@@ -36,10 +36,10 @@ export default class DynamicRadar extends Radar {
     // Create the SkipList only after the estimateHeight has been calculated the first time
     if (this.skipList === null) {
       this.skipList = new SkipList(this.totalItems, this._estimateHeight);
-      this.rbTreeWrapper = new RbTreeWrapper(this.totalItems, this._estimateHeight);
+      // this.rbTreeWrapper = new RbTreeWrapper(this.totalItems, this._estimateHeight);
     } else {
       this.skipList.defaultValue = this._estimateHeight;
-      this.rbTreeWrapper.defaultValue = this._estimateHeight;
+      // this.rbTreeWrapper.defaultValue = this._estimateHeight;
     }
   }
 
@@ -74,16 +74,16 @@ export default class DynamicRadar extends Radar {
     // const { values } = skipList;
 
     let { totalBefore, totalAfter, index: middleItemIndex } = this.skipList.find(visibleMiddle);
-    let { totalBefore: before2, totalAfter: after2, index: index2 } = this.rbTreeWrapper.find(visibleMiddle);
-    if (index2 === middleItemIndex) {
-      console.log('Equal ' + index2);
-    }
-    if (before2 !== totalBefore || after2 !== totalAfter || index2 !== middleItemIndex) {
-      console.log(middleItemIndex, index2, totalBefore, before2);
-      // debugger
-      // this.rbTreeWrapper.find(visibleMiddle);
-      // throw new Error('Not matching')
-    }
+    // let { totalBefore: before2, totalAfter: after2, index: index2 } = this.rbTreeWrapper.find(visibleMiddle);
+    // if (index2 === middleItemIndex) {
+    //   console.log('Equal ' + index2);
+    // }
+    // if (before2 !== totalBefore || after2 !== totalAfter || index2 !== middleItemIndex) {
+    //   console.log(middleItemIndex, index2, totalBefore, before2);
+    //   // debugger
+    //   // this.rbTreeWrapper.find(visibleMiddle);
+    //   // throw new Error('Not matching')
+    // }
 
     const maxIndex = totalItems - 1;
 
@@ -103,18 +103,18 @@ export default class DynamicRadar extends Radar {
     // Add buffers
     for (let i = middleItemIndex - 1; i >= firstItemIndex; i--) {
       const value = skipList.getValues(i);
-      if (Math.abs(value - rbTreeWrapper.getValues(i)) > 0.01) {
-        debugger;
-        rbTreeWrapper.getValues(i)
-      }
+      // if (Math.abs(value - rbTreeWrapper.getValues(i)) > 0.01) {
+      //   debugger;
+      //   rbTreeWrapper.getValues(i)
+      // }
       totalBefore -= value;
     }
 
     for (let i = middleItemIndex + 1; i <= lastItemIndex; i++) {
       const value = skipList.getValues(i);
-      if (Math.abs(value - rbTreeWrapper.getValues(i)) > 0.01) {
-        debugger;
-      }
+      // if (Math.abs(value - rbTreeWrapper.getValues(i)) > 0.01) {
+      //   debugger;
+      // }
       totalAfter -= value;
     }
 
@@ -170,7 +170,7 @@ export default class DynamicRadar extends Radar {
       }
 
       const itemDelta = skipList.set(itemIndex, roundTo(currentItemHeight + margin));
-      rbTreeWrapper.set(itemIndex, roundTo(currentItemHeight + margin));
+      // rbTreeWrapper.set(itemIndex, roundTo(currentItemHeight + margin));
 
       if (itemDelta !== 0) {
         totalDelta += itemDelta;
@@ -226,14 +226,14 @@ export default class DynamicRadar extends Radar {
     super.prepend(numPrepended);
 
     this.skipList.prepend(numPrepended);
-    this.rbTreeWrapper.prepend(numPrepended);
+    // this.rbTreeWrapper.prepend(numPrepended);
   }
 
   append(numAppended) {
     super.append(numAppended);
 
     this.skipList.append(numAppended);
-    this.rbTreeWrapper.append(numAppended);
+    // this.rbTreeWrapper.append(numAppended);
   }
 
   reset() {
@@ -241,7 +241,7 @@ export default class DynamicRadar extends Radar {
 
     if (this.skipList !== null) {
       this.skipList.reset(this.totalItems);
-      this.rbTreeWrapper.reset(this.totalItems);
+      // this.rbTreeWrapper.reset(this.totalItems);
     }
   }
 

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -79,7 +79,7 @@ export default class DynamicRadar extends Radar {
       console.log('Equal ' + index2);
     }
     if (before2 !== totalBefore || after2 !== totalAfter || index2 !== middleItemIndex) {
-      console.log(middleItemIndex, index2);
+      console.log(middleItemIndex, index2, totalBefore, before2);
       // debugger
       // this.rbTreeWrapper.find(visibleMiddle);
       // throw new Error('Not matching')

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -1,7 +1,6 @@
 import Radar from './radar';
 // import SkipList from '../skip-list';
 import SkipList from '../rb-tree/rb-tree-wrapper';
-// import RbTreeWrapper from '../rb-tree/rb-tree-wrapper';
 import roundTo from '../utils/round-to';
 
 import { stripInProduction } from 'vertical-collection/-debug/helpers';
@@ -17,7 +16,6 @@ export default class DynamicRadar extends Radar {
     this._totalAfter = 0;
 
     this.skipList = null;
-    this.rbTreeWrapper =  null;
 
     stripInProduction(() => {
       Object.preventExtensions(this);
@@ -36,17 +34,14 @@ export default class DynamicRadar extends Radar {
     // Create the SkipList only after the estimateHeight has been calculated the first time
     if (this.skipList === null) {
       this.skipList = new SkipList(this.totalItems, this._estimateHeight);
-      // this.rbTreeWrapper = new RbTreeWrapper(this.totalItems, this._estimateHeight);
     } else {
       this.skipList.defaultValue = this._estimateHeight;
-      // this.rbTreeWrapper.defaultValue = this._estimateHeight;
     }
   }
 
   _updateIndexes() {
     const {
       skipList,
-      rbTreeWrapper,
       visibleMiddle,
       totalItems,
       totalComponents,
@@ -71,19 +66,9 @@ export default class DynamicRadar extends Radar {
       this._measure();
     }
 
-    // const { values } = skipList;
+    const { values } = skipList;
 
     let { totalBefore, totalAfter, index: middleItemIndex } = this.skipList.find(visibleMiddle);
-    // let { totalBefore: before2, totalAfter: after2, index: index2 } = this.rbTreeWrapper.find(visibleMiddle);
-    // if (index2 === middleItemIndex) {
-    //   console.log('Equal ' + index2);
-    // }
-    // if (before2 !== totalBefore || after2 !== totalAfter || index2 !== middleItemIndex) {
-    //   console.log(middleItemIndex, index2, totalBefore, before2);
-    //   // debugger
-    //   // this.rbTreeWrapper.find(visibleMiddle);
-    //   // throw new Error('Not matching')
-    // }
 
     const maxIndex = totalItems - 1;
 
@@ -102,20 +87,11 @@ export default class DynamicRadar extends Radar {
 
     // Add buffers
     for (let i = middleItemIndex - 1; i >= firstItemIndex; i--) {
-      const value = skipList.getValues(i);
-      // if (Math.abs(value - rbTreeWrapper.getValues(i)) > 0.01) {
-      //   debugger;
-      //   rbTreeWrapper.getValues(i)
-      // }
-      totalBefore -= value;
+      totalBefore -= values[i];
     }
 
     for (let i = middleItemIndex + 1; i <= lastItemIndex; i++) {
-      const value = skipList.getValues(i);
-      // if (Math.abs(value - rbTreeWrapper.getValues(i)) > 0.01) {
-      //   debugger;
-      // }
-      totalAfter -= value;
+      totalAfter -= values[i];
     }
 
     const itemDelta = (_prevFirstItemIndex !== null) ? firstItemIndex - _prevFirstItemIndex : lastItemIndex - firstItemIndex;
@@ -143,8 +119,7 @@ export default class DynamicRadar extends Radar {
       orderedComponents,
       itemContainer,
       totalBefore,
-      skipList,
-      rbTreeWrapper
+      skipList
     } = this;
 
     const numToMeasure = measureLimit !== null ? measureLimit : orderedComponents.length;
@@ -170,7 +145,6 @@ export default class DynamicRadar extends Radar {
       }
 
       const itemDelta = skipList.set(itemIndex, roundTo(currentItemHeight + margin));
-      // rbTreeWrapper.set(itemIndex, roundTo(currentItemHeight + margin));
 
       if (itemDelta !== 0) {
         totalDelta += itemDelta;
@@ -181,7 +155,6 @@ export default class DynamicRadar extends Radar {
   }
 
   get total() {
-    debugger
     return this.skipList.total;
   }
 
@@ -226,14 +199,12 @@ export default class DynamicRadar extends Radar {
     super.prepend(numPrepended);
 
     this.skipList.prepend(numPrepended);
-    // this.rbTreeWrapper.prepend(numPrepended);
   }
 
   append(numAppended) {
     super.append(numAppended);
 
     this.skipList.append(numAppended);
-    // this.rbTreeWrapper.append(numAppended);
   }
 
   reset() {
@@ -241,7 +212,6 @@ export default class DynamicRadar extends Radar {
 
     if (this.skipList !== null) {
       this.skipList.reset(this.totalItems);
-      // this.rbTreeWrapper.reset(this.totalItems);
     }
   }
 

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -66,8 +66,6 @@ export default class DynamicRadar extends Radar {
       this._measure();
     }
 
-    const { values } = skipList;
-
     let { totalBefore, totalAfter, index: middleItemIndex } = this.skipList.find(visibleMiddle);
 
     const maxIndex = totalItems - 1;
@@ -87,11 +85,11 @@ export default class DynamicRadar extends Radar {
 
     // Add buffers
     for (let i = middleItemIndex - 1; i >= firstItemIndex; i--) {
-      totalBefore -= values[i];
+      totalBefore -= skipList.getValues(i);
     }
 
     for (let i = middleItemIndex + 1; i <= lastItemIndex; i++) {
-      totalAfter -= values[i];
+      totalAfter -= skipList.getValues(i);
     }
 
     const itemDelta = (_prevFirstItemIndex !== null) ? firstItemIndex - _prevFirstItemIndex : lastItemIndex - firstItemIndex;

--- a/addon/-private/data-view/rb-tree/node.js
+++ b/addon/-private/data-view/rb-tree/node.js
@@ -202,7 +202,7 @@ export class Node {
     if (this.left !== null) {
       sum += this.left.debugSum();
     }
-    if (this.data.leftSum !== sum) {
+    if (this.data.leftSum !== sum && Math.abs(this.data.leftSum - sum) > 0.0001) {
       this.printNode(0);
       throw new Error('Sum does not match: ' + this.data.start + ' ' + this.data.leftSum + ' ' + sum);
     }

--- a/addon/-private/data-view/rb-tree/node.js
+++ b/addon/-private/data-view/rb-tree/node.js
@@ -1,0 +1,216 @@
+export const COLOR_BLACK = 1;
+export const COLOR_RED = 2;
+
+export class Node {
+  constructor(data) {
+    this.data = data;
+    this.data.leftSum = this.getTotalIntervalValue();
+
+    this.color = COLOR_BLACK;
+
+    this.left = null;
+    this.right = null;
+    this.parent = null;
+  }
+
+  printNode(depth) {
+    const color = this.color === COLOR_BLACK ? 'B' : 'R';
+    console.log(' '.repeat(2 * depth) + '[' + this.data.start + ', ' + this.data.end + '] ' + this.data.value + color);
+    if (this.left !== null) {
+      this.left.printNode(depth + 1);
+    }
+    if (this.right !== null) {
+      this.right.printNode(depth + 1);
+    }
+  }
+
+  getData() {
+    return this.data;
+  }
+
+  getLeft() {
+    return this.left;
+  }
+
+  getRight() {
+    return this.right;
+  }
+
+  setLeft(childNode) {
+    let delta = 0;
+    if (this.left != null) {
+      // Subtract old sum
+      delta -= this.left.getTotalSum();
+      this.left.parent = null;
+    }
+
+    if (childNode != null) {
+      childNode.removeFromParent();
+      childNode.parent = this;
+      delta += childNode.getTotalSum();
+    }
+    this.left = childNode;
+
+    if (delta != 0) {
+      this.updateSum(delta, true);
+    }
+  }
+
+  setRight(childNode) {
+    let delta = 0;
+    // Break old links, then reconnect properly.
+    if (this.right != null) {
+      delta -= this.right.getTotalSum();
+      this.right.parent = null;
+    }
+    if (childNode != null) {
+      childNode.removeFromParent();
+      childNode.parent = this;
+      delta += childNode.getTotalSum();
+    }
+    this.right = childNode;
+
+    if (delta != 0) {
+      this.updateSum(delta, false);
+    }
+  }
+
+  updateSum(delta, updateCurrentNode) {
+    let node = this;
+    let shouldUpdate = updateCurrentNode;
+
+    while (node != null) {
+      if (shouldUpdate) {
+        node.data.leftSum += delta;
+      }
+      const parent = node.parent;
+      if (parent === null) {
+        break;
+      }
+      if (node === parent.getLeft()) {
+        // node is a left child of parent, continue going up.
+        shouldUpdate = true;
+      } else {
+        shouldUpdate = false;
+      }
+      node = parent;
+    }
+  }
+
+  getParent() {
+    return this.parent;
+  }
+
+  getIntervalLength() {
+    return this.data.end - this.data.start + 1;
+  }
+
+  getTotalIntervalValue() {
+    return (this.data.end - this.data.start + 1) * this.data.value;
+  }
+
+  setData(data, forceUpdate) {
+    if (forceUpdate) {
+      const delta = data.leftSum - this.data.leftSum;
+      this.updateSum(delta, true);
+
+      this.data = data;
+      return;
+    }
+
+    const delta = (data.value - this.data.value) * this.getIntervalLength();
+    const newSum = this.data.leftSum + delta;
+    this.updateSum(delta, true);
+
+    this.data = {
+      start: data.start,
+      end: data.end,
+      value: data.value,
+      sum: newSum
+    }
+  }
+
+  getLeftSum() {
+    return this.data.leftSum;
+  }
+
+  getStrictLeftSum() {
+    return this.data.leftSum - this.getTotalIntervalValue();
+  }
+
+  /**
+   * Gets value of the left most leaf of this tree.
+   */
+  getLeftMostValue() {
+    let value;
+    let node = this;
+    while (node !== null) {
+      value = node.data.value;
+      node = node.left;
+    }
+    return value;
+  }
+
+  getTotalSum() {
+    let node = this;
+    let sum = 0;
+    while (node !== null) {
+      sum += node.data.leftSum;
+      node = node.right;
+    }
+    return sum;
+  }
+
+  removeFromParent() {
+    const parent = this.parent;
+    if (parent !== null) {
+      if (this === parent.getLeft()) {
+        parent.setLeft(null);
+
+      } else if (this === parent.getRight()) {
+        parent.setRight(null);
+      } else {
+        throw new Error("Invalid state.");
+      }
+    }
+  }
+
+  getColorString() {
+    return this.color === COLOR_BLACK ? 'B' : 'R';
+  }
+
+  getDebugObject() {
+    const obj = {};
+    obj.data = this.data.value + this.getColorString();
+    if (this.left === null) {
+      obj.left = "";
+    } else {
+      obj.left = this.left.getDebugObject();
+    }
+
+    if (this.right === null) {
+      obj.right = "";
+    } else {
+      obj.right = this.right.getDebugObject();
+    }
+
+    return obj;
+  }
+
+  debugSum() {
+    let sum = this.getTotalIntervalValue();
+    if (this.left !== null) {
+      sum += this.left.debugSum();
+    }
+    if (this.data.leftSum !== sum) {
+      this.printNode(0);
+      throw new Error('Sum does not match: ' + this.data.start + ' ' + this.data.leftSum + ' ' + sum);
+    }
+
+    let rightSum = 0;
+    if (this.right !== null) {
+      rightSum = this.right.debugSum();
+    }
+    return sum + rightSum;
+  }
+}

--- a/addon/-private/data-view/rb-tree/node.js
+++ b/addon/-private/data-view/rb-tree/node.js
@@ -2,11 +2,13 @@ export const COLOR_BLACK = 1;
 export const COLOR_RED = 2;
 
 export class Node {
+
   constructor(data) {
     this.data = data;
     this.data.leftSum = this.getTotalIntervalValue();
 
     this.color = COLOR_BLACK;
+    this.debugMode = true;
 
     this.left = null;
     this.right = null;
@@ -151,6 +153,16 @@ export class Node {
     return value;
   }
 
+  getRightMostData() {
+    let data = null;
+    let node = this;
+    while (node !== null) {
+      data = node.data;
+      node = node.right;
+    }
+    return data;
+  }
+
   getTotalSum() {
     let node = this;
     let sum = 0;
@@ -198,11 +210,15 @@ export class Node {
   }
 
   debugSum() {
+    if (!this.debugMode) {
+      return;
+    }
+
     let sum = this.getTotalIntervalValue();
     if (this.left !== null) {
       sum += this.left.debugSum();
     }
-    if (this.data.leftSum !== sum && Math.abs(this.data.leftSum - sum) > 0.0001) {
+    if (Math.abs(this.data.leftSum - sum) > 0.5) {
       this.printNode(0);
       throw new Error('Sum does not match: ' + this.data.start + ' ' + this.data.leftSum + ' ' + sum);
     }

--- a/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
+++ b/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
@@ -8,7 +8,11 @@ export default class RbTreeWrapper {
   }
 
   find(targetValue) {
-    return this.tree.findMaxIndex(targetValue);;
+    let ret = this.tree.findMaxIndex(targetValue);;
+    if (ret.index !== 0) {
+      ret = this.tree.getTriple(ret.index + 1);
+    }
+    return ret;
   }
 
   getOffset(targetIndex) {

--- a/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
+++ b/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
@@ -1,4 +1,5 @@
 import RedBlackTree from './red-black-tree';
+import roundTo from '../utils/round-to';
 
 export default class RbTreeWrapper {
   constructor(length, defaultValue) {
@@ -7,7 +8,7 @@ export default class RbTreeWrapper {
   }
 
   find(targetValue) {
-    return this.tree.findMaxIndex(targetValue);
+    return this.tree.findMaxIndex(targetValue);;
   }
 
   getOffset(targetIndex) {
@@ -16,7 +17,14 @@ export default class RbTreeWrapper {
   }
 
   set(index, value) {
+    const oldValue = this.tree.getValueAtIndex(index);
     this.tree.update(index, value);
+
+    return roundTo(value - oldValue);
+  }
+
+  getValues(index) {
+    return this.tree.getValueAtIndex(index);
   }
 
   prepend(numPrepended) {
@@ -24,13 +32,7 @@ export default class RbTreeWrapper {
       return;
     }
 
-    const oldSmallestIndex = this.smallesIndex;
-    tree.add({
-      start: oldSmallestIndex - numPrepended,
-      end: oldSmallestIndex - 1,
-      value: this.defaultValue
-    });
-    thils.smallesIndex = oldSmallestIndex - numPrepended;
+    this.tree.prepend(numPrepended, this.defaultValue);
   }
 
   append(numAppended) {
@@ -38,8 +40,11 @@ export default class RbTreeWrapper {
       return;
     }
 
+    throw new Error("Not supported yet")
+    // TODO(Billy): support append.
+
     const oldBiggestIndex = this.biggestIndex;
-    tree.add({
+    this.tree.add({
       start: oldBiggestIndex + numAppended,
       end: oldBiggestIndex + 1,
       value: this.defaultValue
@@ -53,11 +58,9 @@ export default class RbTreeWrapper {
 
   _createTree(length) {
     this.length = length;
-    this.smallesIndex = 0;
-    this.biggestIndex = length - 1;
 
     this.tree = new RedBlackTree();
-    tree.add({
+    this.tree.add({
       start: 0,
       end: length - 1,
       value: this.defaultValue

--- a/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
+++ b/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
@@ -40,16 +40,7 @@ export default class RbTreeWrapper {
       return;
     }
 
-    throw new Error("Not supported yet")
-    // TODO(Billy): support append.
-
-    const oldBiggestIndex = this.biggestIndex;
-    this.tree.add({
-      start: oldBiggestIndex + numAppended,
-      end: oldBiggestIndex + 1,
-      value: this.defaultValue
-    });
-    this.biggestIndex = oldBiggestIndex + numAppended;
+    this.tree.append(numAppended, this.defaultValue);
   }
 
   reset(newLength) {

--- a/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
+++ b/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
@@ -1,0 +1,66 @@
+import RedBlackTree from './red-black-tree';
+
+export default class RbTreeWrapper {
+  constructor(length, defaultValue) {
+    this.defaultValue = defaultValue;
+    this._createTree(length);
+  }
+
+  find(targetValue) {
+    return this.tree.findMaxIndex(targetValue);
+  }
+
+  getOffset(targetIndex) {
+    // TODO(Billy): Figure out what offset function in the skip list does.
+    throw new Error('Unsupported function');
+  }
+
+  set(index, value) {
+    this.tree.update(index, value);
+  }
+
+  prepend(numPrepended) {
+    if (numPrepended === 0) {
+      return;
+    }
+
+    const oldSmallestIndex = this.smallesIndex;
+    tree.add({
+      start: oldSmallestIndex - numPrepended,
+      end: oldSmallestIndex - 1,
+      value: this.defaultValue
+    });
+    thils.smallesIndex = oldSmallestIndex - numPrepended;
+  }
+
+  append(numAppended) {
+    if (numAppended === 0) {
+      return;
+    }
+
+    const oldBiggestIndex = this.biggestIndex;
+    tree.add({
+      start: oldBiggestIndex + numAppended,
+      end: oldBiggestIndex + 1,
+      value: this.defaultValue
+    });
+    this.biggestIndex = oldBiggestIndex + numAppended;
+  }
+
+  reset(newLength) {
+    this._createTree(newLength);
+  }
+
+  _createTree(length) {
+    this.length = length;
+    this.smallesIndex = 0;
+    this.biggestIndex = length - 1;
+
+    this.tree = new RedBlackTree();
+    tree.add({
+      start: 0,
+      end: length - 1,
+      value: this.defaultValue
+    });
+  }
+}

--- a/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
+++ b/addon/-private/data-view/rb-tree/rb-tree-wrapper.js
@@ -9,7 +9,7 @@ export default class RbTreeWrapper {
 
   find(targetValue) {
     let ret = this.tree.findMaxIndex(targetValue);;
-    if (ret.index !== 0) {
+    if (ret.index !== 0 && ret.index < this.length - 1) {
       ret = this.tree.getTriple(ret.index + 1);
     }
     return ret;

--- a/addon/-private/data-view/rb-tree/red-black-tree.js
+++ b/addon/-private/data-view/rb-tree/red-black-tree.js
@@ -5,6 +5,7 @@ export default class RedBlackTree {
   constructor() {
     this.root = null;
     this.minIndex = 0;
+    this.maxIndex = 0;
   }
 
   printTree() {
@@ -484,6 +485,7 @@ export default class RedBlackTree {
         n = n.getRight();
       }
     }
+    return null;
   }
 
   findMaxIndex(targetValue) {
@@ -577,6 +579,19 @@ export default class RedBlackTree {
     this.add({
       start: this.minIndex,
       end: this.minIndex + itemCount - 1,
+      value: value
+    });
+  }
+
+  append(itemCount, value) {
+    if (this.root !== null) {
+      const data = this.root.getRightMostData();
+      this.maxIndex = data.end;
+    }
+
+    this.add({
+      start: this.maxIndex + 1,
+      end: this.maxIndex + itemCount,
       value: value
     });
   }

--- a/addon/-private/data-view/rb-tree/red-black-tree.js
+++ b/addon/-private/data-view/rb-tree/red-black-tree.js
@@ -574,7 +574,7 @@ export default class RedBlackTree {
             index = nodeData.start;
           } else {
             index = Math.floor((remainingValue - nodeData.value) / nodeData.value) + nodeData.start;
-            assert('index should be bigger than start', index > nodeData.start);
+            assert('index should be bigger than start', index >= nodeData.start);
             totalBefore += (index - nodeData.start) * nodeData.value;
           }
         }

--- a/addon/-private/data-view/rb-tree/red-black-tree.js
+++ b/addon/-private/data-view/rb-tree/red-black-tree.js
@@ -1,0 +1,562 @@
+import { Node, COLOR_BLACK, COLOR_RED } from './node';
+import { assert } from 'vertical-collection/-debug/helpers';
+
+export default class RedBlackTree {
+  constructor() {
+    this.root = null;
+  }
+
+  printTree() {
+    if (this.root !== null) {
+      this.root.printNode(0);
+    }
+  }
+
+  add(data) {
+    if (this.root == null) {
+      this.root = new Node(data);
+      return;
+    }
+
+    let n = this.root;
+    while (n !== null) {
+      const comparisonResult = this.compareNode(data, n.getData());
+      if (comparisonResult == 0) {
+        n.setData(data);
+        return;
+      } else if (comparisonResult < 0) {
+        if (n.getLeft() == null) {
+          n.setLeft(new Node(data));
+          this.adjustAfterInsertion(n.getLeft());
+          break;
+        }
+        n = n.getLeft();
+      } else { // comparisonResult > 0
+        if (n.getRight() == null) {
+          n.setRight(new Node(data));
+          this.adjustAfterInsertion(n.getRight());
+          break;
+        }
+        n = n.getRight();
+      }
+    }
+
+    this.debugSum();
+  }
+
+  remove(data) {
+    let node = this.nodeContaining(data);
+    if (node == null) {
+      // No such object, do nothing.
+      return;
+    }
+
+    if (node.getLeft() != null && node.getRight() != null) {
+        // Node has two children, Copy predecessor data in.
+        const predecessor = this.predecessor(node);
+        node.setData(predecessor.getData());
+        this.debugSum();
+        node = predecessor;
+    }
+
+    this.debugSum();
+
+    // At this point node has zero or one child
+    const pullUp = this.leftOf(node) == null ? this.rightOf(node) : this.leftOf(node);
+    if (pullUp != null) {
+      // Splice out node, and adjust if pullUp is a double black.
+      if (node == this.root) {
+        this.setRoot(pullUp);
+      } else if (node.getParent().getLeft() == node) {
+        node.getParent().setLeft(pullUp);
+      } else {
+        node.getParent().setRight(pullUp);
+      }
+
+      if (this.isBlack(node)) {
+        this.adjustAfterRemoval(pullUp);
+      }
+    } else if (node == this.root) {
+      // Nothing to pull up when deleting a this.root means we emptied the tree
+      this.setRoot(null);
+    } else {
+      // The node being deleted acts as a double black sentinel
+      if (this.isBlack(node)) {
+          this.adjustAfterRemoval(node);
+      }
+      node.removeFromParent();
+    }
+
+    if (this.root !== null) {
+      this.debugSum();
+    }
+  }
+
+  adjustAfterInsertion(n) {
+    // Step 1: color the node red
+    this.setColor(n, COLOR_RED);
+
+    // Step 2: Correct double red problems, if they exist
+    if (n != null && n != this.root && this.isRed(this.parentOf(n))) {
+
+      // Step 2a (simplest): Recolor, and move up to see if more work
+      // needed
+      if (this.isRed(this.siblingOf(this.parentOf(n)))) {
+        this.setColor(this.parentOf(n), COLOR_BLACK);
+        this.setColor(this.siblingOf(this.parentOf(n)), COLOR_BLACK);
+        this.setColor(this.grandparentOf(n), COLOR_RED);
+        this.adjustAfterInsertion(this.grandparentOf(n));
+      }
+
+      // Step 2b: Restructure for a parent who is the left child of the
+      // grandparent. This will require a single right rotation if n is
+      // also
+      // a left child, or a left-right rotation otherwise.
+      else if (this.parentOf(n) == this.leftOf(this.grandparentOf(n))) {
+        if (n == this.rightOf(this.parentOf(n))) {
+          n = this.parentOf(n);
+          this.rotateLeft(n);
+        }
+        this.setColor(this.parentOf(n), COLOR_BLACK);
+        this.setColor(this.grandparentOf(n), COLOR_RED);
+        this.rotateRight(this.grandparentOf(n));
+      }
+
+      // Step 2c: Restructure for a parent who is the right child of the
+      // grandparent. This will require a single left rotation if n is
+      // also
+      // a right child, or a right-left rotation otherwise.
+      else if (this.parentOf(n) == this.rightOf(this.grandparentOf(n))) {
+        if (n == this.leftOf(this.parentOf(n))) {
+          this.rotateRight(n = this.parentOf(n));
+        }
+        this.setColor(this.parentOf(n), COLOR_BLACK);
+        this.setColor(this.grandparentOf(n), COLOR_RED);
+        this.rotateLeft(this.grandparentOf(n));
+      }
+    }
+
+    // Step 3: Color the root black
+    this.setColor(this.root, COLOR_BLACK);
+  }
+
+  adjustAfterRemoval(n) {
+    while (n != this.root && this.isBlack(n)) {
+      if (n == this.leftOf(this.parentOf(n))) {
+        // Pulled up node is a left child
+        let sibling = this.rightOf(this.parentOf(n));
+        if (this.isRed(sibling)) {
+          this.setColor(sibling, COLOR_BLACK);
+          this.setColor(this.parentOf(n), COLOR_RED);
+          this.rotateLeft(this.parentOf(n));
+          sibling = this.rightOf(this.parentOf(n));
+        }
+        if (this.isBlack(this.leftOf(sibling)) && this.isBlack(this.rightOf(sibling))) {
+          this.setColor(sibling, COLOR_RED);
+          n = this.parentOf(n);
+        } else {
+          if (this.isBlack(this.rightOf(sibling))) {
+            this.setColor(this.leftOf(sibling), COLOR_BLACK);
+            this.setColor(sibling, COLOR_RED);
+            this.rotateRight(sibling);
+            sibling = this.rightOf(this.parentOf(n));
+          }
+          this.setColor(sibling, this.colorOf(this.parentOf(n)));
+          this.setColor(this.parentOf(n), COLOR_BLACK);
+          this.setColor(this.rightOf(sibling), COLOR_BLACK);
+          this.rotateLeft(this.parentOf(n));
+          n = this.root;
+        }
+      } else {
+        // pulled up node is a right child
+        let sibling = this.leftOf(this.parentOf(n));
+        if (this.isRed(sibling)) {
+          this.setColor(sibling, COLOR_BLACK);
+          this.setColor(this.parentOf(n), COLOR_RED);
+          this.rotateRight(this.parentOf(n));
+          sibling = this.leftOf(this.parentOf(n));
+        }
+        if (this.isBlack(this.leftOf(sibling)) && this.isBlack(this.rightOf(sibling))) {
+          this.setColor(sibling, COLOR_RED);
+          n = this.parentOf(n);
+        } else {
+          if (this.isBlack(this.leftOf(sibling))) {
+            this.setColor(this.rightOf(sibling), COLOR_BLACK);
+            this.setColor(sibling, COLOR_RED);
+            this.rotateLeft(sibling);
+            sibling = this.leftOf(this.parentOf(n));
+          }
+          this.setColor(sibling, this.colorOf(this.parentOf(n)));
+          this.setColor(this.parentOf(n), COLOR_BLACK);
+          this.setColor(this.leftOf(sibling), COLOR_BLACK);
+          this.rotateRight(this.parentOf(n));
+          n = this.root;
+        }
+      }
+    }
+    this.setColor(n, COLOR_BLACK);
+  }
+
+  colorOf(n) {
+    return n == null ? COLOR_BLACK : n.color;
+  }
+
+  isRed(n) {
+      return n != null && this.colorOf(n) == COLOR_RED;
+  }
+
+  isBlack(n) {
+      return n == null || this.colorOf(n) == COLOR_BLACK;
+  }
+
+  setColor(n, c) {
+    if (n != null) {
+      n.color = c;
+    }
+  }
+
+  parentOf(n) {
+    return n == null ? null : n.getParent();
+  }
+
+  grandparentOf(n) {
+    return (n == null || n.getParent() == null) ? null : n .getParent().getParent();
+  }
+
+  siblingOf(n) {
+    return (n == null || n.getParent() == null) ? null : (n == n
+            .getParent().getLeft()) ? n.getParent().getRight()
+            : n.getParent().getLeft();
+  }
+
+  leftOf(n) {
+      return n == null ? null : n.getLeft();
+  }
+
+  rightOf(n) {
+      return n == null ? null : n.getRight();
+  }
+
+  nodeContaining(data) {
+    let n = this.root;
+
+    while (n !== null) {
+      const comparisonResult = this.compareNode(data, n.getData());
+      if (comparisonResult == 0) {
+        return n;
+      } else if (comparisonResult < 0) {
+        n = n.getLeft();
+      } else {
+        n = n.getRight();
+      }
+    }
+
+    return null;
+  }
+
+  setRoot(node) {
+    if (node != null) {
+      node.removeFromParent();
+    }
+    this.root = node;
+  }
+
+  rotateLeft(n) {
+    if (n.getRight() == null) {
+      return;
+    }
+
+    const oldRight = n.getRight();
+    const oldRightLeft = oldRight.getLeft();
+
+    if (oldRightLeft !== null) {
+      oldRightLeft.removeFromParent();
+    }
+
+    this.debugSum();
+
+    n.setRight(oldRightLeft);
+    this.debugSum();
+
+    if (n.getParent() == null) {
+        this.root = oldRight;
+    } else if (n.getParent().getLeft() == n) {
+        n.getParent().setLeft(oldRight);
+    } else {
+        n.getParent().setRight(oldRight);
+    }
+    oldRight.setLeft(n);
+
+    this.debugSum();
+  }
+
+  rotateRight(n) {
+    if (n.getLeft() == null) {
+      return;
+    }
+
+    const oldLeft = n.getLeft();
+    const oldLeftRight = oldLeft.getRight(); // right child of the old left.
+    if (oldLeftRight !== null) {
+      oldLeftRight.removeFromParent();
+    }
+
+    n.setLeft(oldLeftRight);
+    if (n.getParent() == null) {
+        this.root = oldLeft;
+    } else if (n.getParent().getLeft() == n) {
+        n.getParent().setLeft(oldLeft);
+    } else {
+        n.getParent().setRight(oldLeft);
+    }
+    oldLeft.setRight(n);
+
+    this.debugSum();
+  }
+
+  update(index, value) {
+    const data = {
+      start: index,
+      end: index,
+      value
+    };
+
+    const node = this.nodeContainingIndex(index);
+    if (node === null) {
+      throw new Error('Node cannot be found for ' + index + ' ' + value);
+    }
+    if (index < node.data.start || index > node.data.end) {
+      throw new Error('Invalid node range ' + index + ' ' + start + ' ' + end);
+    }
+    if (value === node.data.value) {
+      // Nothing to update
+      return;
+    }
+
+    const { start, end } = node.getData();
+    const sum = node.getLeftSum();
+    const oldValue = node.getData().value;
+
+    if (node.getIntervalLength() === 1) {
+      node.setData({
+        start: index,
+        end: index,
+        value: value,
+        leftSum: node.getLeftSum() - node.getTotalIntervalValue() + (end - start + 1) * value
+      }, true);
+      return;
+    }
+
+    if (index > start && index < end) {
+      // Update this node. This node has an interval of length 1 [index..index]. We create 2 new
+      // interval of the left & right of the index and insert into the tree.
+      node.setData({
+        start: index,
+        end: index,
+        value: value,
+        leftSum: sum - node.getTotalIntervalValue() + value
+      }, true);
+
+      // Create 2 new more nodes for this tree.
+      this.add({
+        start: start,
+        end: index - 1,
+        value: oldValue
+      });
+
+      this.add({
+        start: index + 1,
+        end: end,
+        value: oldValue
+      });
+      return;
+    }
+
+    // Now index is either start or end of the interval.
+    const start1 = start;
+    const end2 = end;
+    let value1 = oldValue;
+    let value2 = oldValue;
+
+    let end1, start2;
+    if (index === start) {
+      end1 = start;
+      start2 = start + 1;
+      value1 = value;
+    } else { // index == end
+      end1 = end - 1;
+      start2 = end;
+      value2 = value;
+    }
+
+    // Keep first interval.
+    node.setData({
+      start: start1,
+      end: end1,
+      value: value1,
+      leftSum: sum - node.getTotalIntervalValue() + (end1 - start1 + 1) * value1
+    }, true);
+
+    // Insert second interval
+    this.add({ start: start2, end: end2, value: value2 });
+
+    this.debugSum();
+  }
+
+  nodeContainingIndex(index) {
+    let n = this.root;
+
+    while (n !== null) {
+      const nodeData = n.getData();
+      if (nodeData.start <= index && nodeData.end >= index) {
+        return n;
+      }
+
+      if (nodeData.end < index) {
+        n = n.getRight();
+      } else {
+        n = n.getLeft();
+      }
+    }
+
+    return null;
+  }
+
+  getSum(index) {
+    let sum = 0;
+    let n = this.root;
+
+    const data = {
+      start: index,
+      end: index
+    }
+
+    while (n !== null) {
+      const comparisonResult = this.compareNode(data, n.getData());
+      if (comparisonResult == 0) {
+        sum += n.getLeftSum();
+        break;
+      } else if (comparisonResult < 0) {
+        const nodeData = n.getData();
+        if (index >= nodeData.start) {
+          sum += n.getStrictLeftSum() + (index - nodeData.start + 1) * nodeData.value;
+          break;
+        }
+        n = n.getLeft();
+      } else {
+        sum += n.getLeftSum();
+        n = n.getRight();
+      }
+    }
+
+    return sum;
+  }
+
+  findMaxIndex(targetValue) {
+    let n = this.root;
+    if (n === null) {
+      return {index: 0, totalBefore: 0, totalAfter: 0};
+    }
+
+    if (targetValue === 0) {
+      return { index: 0, totalBefore: 0, totalAfter: this.root.getTotalSum() };
+    }
+
+    let remainingValue = targetValue;
+    let totalBefore = 0;
+    let valueAtIndex = 0;
+    let index = -1;
+
+    const DIRECTION_STAY = 0;
+    const DIRECTION_GO_LEFT = 1;
+    const DIRECTION_GO_RIGHT = 2;
+
+    while (n != null) {
+      const nodeData = n.getData();
+      const strictLeftSum = n.getStrictLeftSum();
+      const leftSum = n.getLeftSum();
+
+      let direction = -1;
+
+      if (remainingValue >= leftSum) {
+        if (n.getRight() !== null) {
+          const minValue = n.getRight().getLeftMostValue();
+          if (minValue > remainingValue - leftSum) {
+            // Stay here.
+            direction = DIRECTION_STAY;
+          } else {
+            direction = DIRECTION_GO_RIGHT;
+          }
+        } else {
+          direction = DIRECTION_STAY;
+        }
+      } else if (remainingValue < strictLeftSum) {
+        direction = DIRECTION_GO_LEFT;
+      } else { // remainingValue >= strictLeftSum && remainingValue < leftSum
+        if (remainingValue - strictLeftSum < nodeData.value) {
+          direction = DIRECTION_GO_LEFT;
+        } else {
+          direction = DIRECTION_STAY;
+        }
+      }
+
+      if (direction === DIRECTION_GO_LEFT) {
+        n = n.getLeft();
+      } else if (direction === DIRECTION_GO_RIGHT) {
+        totalBefore += leftSum;
+        remainingValue -= leftSum;
+        n = n.getRight();
+      } else {
+        remainingValue -= strictLeftSum;
+        totalBefore += strictLeftSum;
+        valueAtIndex = nodeData.value;
+
+        if (nodeData.value === 0) {
+          index = nodeData.end;
+        } else {
+          if (remainingValue <= 2 * nodeData.value - 1) {
+            // totalBefore remains the same.
+            index = nodeData.start;
+          } else {
+            index = Math.floor((remainingValue - nodeData.value) / nodeData.value) + nodeData.start;
+            assert('index should be bigger than start', index > nodeData.start);
+            totalBefore += (index - nodeData.start) * nodeData.value;
+          }
+        }
+        index = Math.min(index, nodeData.end);
+        break;
+      }
+    }
+
+    const totalAfter = this.root.getTotalSum() - totalBefore - valueAtIndex;
+    return { index: index, totalBefore: totalBefore, totalAfter: totalAfter };
+  }
+
+  debugSum() {
+    if (this.root !== null) {
+      this.root.debugSum();
+    }
+  }
+
+  predecessor(node) {
+    let n = node.getLeft();
+    if (n != null) {
+      while (n.getRight() != null) {
+        n = n.getRight();
+      }
+    }
+    return n;
+  }
+
+  compareNode(node1, node2) {
+    if (node1.start === node2.start && node1.end === node2.end) {
+      return 0;
+    }
+
+    if (node1.start >= node2.start && node1.end <= node2.end) {
+      return -1;
+    }
+
+    return node1.start - node2.start;
+  }
+}

--- a/addon/-private/data-view/rb-tree/red-black-tree.js
+++ b/addon/-private/data-view/rb-tree/red-black-tree.js
@@ -427,6 +427,10 @@ export default class RedBlackTree {
 
   getSum(outsideIndex) {
     let index = this.minIndex + outsideIndex;
+    return this._getSum(index);
+  }
+
+  _getSum(index) {
     let sum = 0;
     let n = this.root;
 
@@ -464,6 +468,10 @@ export default class RedBlackTree {
   }
 
   _getValueAtIndex(index) {
+    return this._getDataAtIndex(index).value;
+  }
+
+  _getDataAtIndex(index) {
     let n = this.root;
 
     const data = {
@@ -475,10 +483,10 @@ export default class RedBlackTree {
       const nodeData = n.getData();
       const comparisonResult = this.compareNode(data, nodeData);
       if (comparisonResult == 0) {
-        return nodeData.value;
+        return nodeData;
       } else if (comparisonResult < 0) {
         if (index >= nodeData.start) {
-          return nodeData.value;
+          return nodeData;
         }
         n = n.getLeft();
       } else {
@@ -486,6 +494,16 @@ export default class RedBlackTree {
       }
     }
     return null;
+  }
+
+  getTriple(outsideIndex) {
+    const index = this.minIndex + outsideIndex;
+    const value = this._getValueAtIndex(index);
+    const totalBefore = this._getSum(index) - value;
+    const total = this.root.getTotalSum();
+    const totalAfter = this.root.getTotalSum() - totalBefore - value;
+
+    return { index: index - this.minIndex, totalBefore: totalBefore, totalAfter: totalAfter };
   }
 
   findMaxIndex(targetValue) {

--- a/addon/-private/data-view/rb-tree/red-black-tree.js
+++ b/addon/-private/data-view/rb-tree/red-black-tree.js
@@ -4,6 +4,7 @@ import { assert } from 'vertical-collection/-debug/helpers';
 export default class RedBlackTree {
   constructor() {
     this.root = null;
+    this.minIndex = 0;
   }
 
   printTree() {
@@ -314,14 +315,15 @@ export default class RedBlackTree {
     this.debugSum();
   }
 
-  update(index, value) {
+  update(outsideIndex, value) {
+    let index = this.minIndex + outsideIndex;
     const data = {
       start: index,
       end: index,
       value
     };
 
-    const node = this.nodeContainingIndex(index);
+    const node = this._nodeContainingIndex(index);
     if (node === null) {
       throw new Error('Node cannot be found for ' + index + ' ' + value);
     }
@@ -403,7 +405,7 @@ export default class RedBlackTree {
     this.debugSum();
   }
 
-  nodeContainingIndex(index) {
+  _nodeContainingIndex(index) {
     let n = this.root;
 
     while (n !== null) {
@@ -422,7 +424,8 @@ export default class RedBlackTree {
     return null;
   }
 
-  getSum(index) {
+  getSum(outsideIndex) {
+    let index = this.minIndex + outsideIndex;
     let sum = 0;
     let n = this.root;
 
@@ -452,6 +455,37 @@ export default class RedBlackTree {
     return sum;
   }
 
+  /**
+   * Public function to get an index. This index is the outside index.
+   */
+  getValueAtIndex(outsideIndex) {
+    return this._getValueAtIndex(this.minIndex + outsideIndex);
+  }
+
+  _getValueAtIndex(index) {
+    let n = this.root;
+
+    const data = {
+      start: index,
+      end: index
+    }
+
+    while (n !== null) {
+      const nodeData = n.getData();
+      const comparisonResult = this.compareNode(data, nodeData);
+      if (comparisonResult == 0) {
+        return nodeData.value;
+      } else if (comparisonResult < 0) {
+        if (index >= nodeData.start) {
+          return nodeData.value;
+        }
+        n = n.getLeft();
+      } else {
+        n = n.getRight();
+      }
+    }
+  }
+
   findMaxIndex(targetValue) {
     let n = this.root;
     if (n === null) {
@@ -465,7 +499,8 @@ export default class RedBlackTree {
     let remainingValue = targetValue;
     let totalBefore = 0;
     let valueAtIndex = 0;
-    let index = -1;
+    const MIN = -100000000;
+    let index = MIN;
 
     const DIRECTION_STAY = 0;
     const DIRECTION_GO_LEFT = 1;
@@ -528,8 +563,22 @@ export default class RedBlackTree {
       }
     }
 
+    if (index === MIN) {
+      index = this.minIndex;
+      valueAtIndex = this._getValueAtIndex(index);
+    }
+
     const totalAfter = this.root.getTotalSum() - totalBefore - valueAtIndex;
-    return { index: index, totalBefore: totalBefore, totalAfter: totalAfter };
+    return { index: index - this.minIndex, totalBefore: totalBefore, totalAfter: totalAfter };
+  }
+
+  prepend(itemCount, value) {
+    this.minIndex -= itemCount;
+    this.add({
+      start: this.minIndex,
+      end: this.minIndex + itemCount - 1,
+      value: value
+    });
   }
 
   debugSum() {

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -107,6 +107,10 @@ export default class SkipList {
     this.values = values;
   }
 
+  getValues(index) {
+    return this.values[index];
+  }
+
   find(targetValue) {
     const { layers, total, length, values } = this;
     const numLayers = layers.length;
@@ -189,6 +193,8 @@ export default class SkipList {
     assert('index must be a number', typeof index === 'number');
     assert('index must be within bounds', index >= 0 && index < this.values.length);
 
+    // debugger
+
     const { layers } = this;
     const oldValue = layers[layers.length - 1][index];
     const delta = roundTo(value - oldValue);
@@ -231,6 +237,7 @@ export default class SkipList {
   }
 
   append(numAppended) {
+    debugger
     const {
       values: oldValues,
       length: oldLength,

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -193,8 +193,6 @@ export default class SkipList {
     assert('index must be a number', typeof index === 'number');
     assert('index must be within bounds', index >= 0 && index < this.values.length);
 
-    // debugger
-
     const { layers } = this;
     const oldValue = layers[layers.length - 1][index];
     const delta = roundTo(value - oldValue);
@@ -237,7 +235,6 @@ export default class SkipList {
   }
 
   append(numAppended) {
-    debugger
     const {
       values: oldValues,
       length: oldLength,


### PR DESCRIPTION
# TL; DR
This PR significantly improves performance of vertical collection by replacing skip list with [red black tree](https://en.wikipedia.org/wiki/Red%E2%80%93black_tree) (RBT). It's faster because: 
- Initialization time goes down from O(N) in skip list to O(1) for RB tree.
- Memory usage is O(N) in worse case (same with skip list) but majoriy of cases, the tree uses sub-linear mem usage. In many cases, it's just O(1) !!
- Prepend & append new elements in the tree take O(logN) instead of O(N) for skip list, making infinite scrolling faster.
- Finding partial sum takes O(logN), same with skip list.
- The RB tree implementation is fully functional with demo app. There might be some code I need to clean or tests to add but overall it's good to play around with.

## The partial sum problem
One problem arises from vertical collection implementation is to find a good data structure to efficiently update & retrieve partial sum of an array. The problem could be sumarized as follow:

Let A[1..n] be an array of real numbers. Design an algorithm to perform any sequence of the following operations:
- update(index, value) -- Update position index with a value. 
- find(targetSum): returns the maximum number `i` such that sum(A[0]..A[i]) <= targetSum < sum(A[0]..A[i + 1]). 

There are multiple ways to solve this problem in log(N) time. Common approach is to use some binary search tree. Indeed, the skip list in the current implementation is actually a [binary segment tree](https://en.wikipedia.org/wiki/Segment_tree). Using skip list has a number of advantages, including simple implementation, retrieval & updating take logarith time. However, the biggest issue with skip list is the O(N) initialize time and it's a static array. This means that to support deletion & insertion we have to tear down entire array and recreate it again. 

## Self Balanced Binary Tree Approach. 
The partial sum problem can be solved using any self balanced binary search tree. The algorithm is as follow:
- The search key for the tree is the index in the array. Nodes with indexes bigger than root's index is on the right of the root and vice versa. In addition to that, we store the `sum of left subtree` of any node in the node data, including the node itself. It's important to note that we only store sum of the left subtree because nodes in the right subtree have bigger index.
- update(index, value): we traverse from the root to the node that has index. Update its left tree sum and all of its parents whose left subtree also contains that node.
- find(targetSum): We traverse from the root. If the `targetSum` is bigger that left subtree sum, go to the right. If it's smaller or equal than `strict left subtree` sum, traverse to the left.
- Prepend & Append items take O(logN) as a normal self balanced binary search tree.

Main advatages of using BST is that it's a dynamic structure. This means that you can delay tree initialization until we only need to process actual data. Deletion & insertion items take only O(logN). More importantly, it allows use to have sub-linear memory usage on average like described in the section below.

## Sub-linear memory usage. 
How can we have sub-linear usage if we have at least N items?
The answer is at the nature of vertical collection (VC). Main usage of VC is for list or table data. For long list with more than 10k items, most items or rows have the same height. Instead of storing single item index in the node, we store a continuous block of items with same height. Each node in the tree represents an interval `[start..end]` for items with same height. It keeps `start`, `end` and `height` variable. The tree still complies with its BST restriction but we have much less nodes in the tree and hence faster searching & updating. 

Updating an index might require splitting a node into 3 different nodes. For example, if the interval is [6 6 6 6 6] and we want to update middle index with 5, the node is splited into 3 nodes [6 6] [5] [6 6]. This operation is the same like inserting new node into a tree and takes O(logN)

As VC use estimate height for array initialization, we can assume that all items have same height at the beginning. If all rows in the list/ table have the same height, we have only 1 node or O(1) mem usage!!! Indeed, I believe that any list with more than 10k items will very likely have item with same height. 

The last question we have to answer is what self balance BST tree should we use? 

## Red Black tree vs AVL tree vs other self balance BST
I have considered a number of trees for implementation. My initial approach was to use [AVL tree](https://en.wikipedia.org/wiki/AVL_tree) because it has faster retrieval time. As I observe, we indeed have more node insertion & deletion than query. This is especially true when we use an interval `[start..end]` in a node and updating an index falling in between the interval with different height means splitting up the interval into 3 sub intervals. AVL is more rigidly balanced and hence provide faster look-ups. RB has smaller number of tree rotation on average and hence provide a better performance. In fact, most common std library uses RB tree for their map & set implementation. 