### PR TITLE
(bugfix): set correct max height.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
   rules: {
     'quotes': ['error', 'single', {  "allowTemplateLiterals": true, "avoidEscape": true }],
     'ember-suave/no-const-outside-module-scope': 0,
-    'ember-suave/no-direct-property-access': 1
+    'ember-suave/no-direct-property-access': 1,
+    'ember-suave/require-access-in-comments': 0
   }
 };

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -218,7 +218,7 @@ export default class Radar {
     let maxHeight = 0;
     if (scrollContainer instanceof Element) {
       const maxHeightString = window.getComputedStyle(scrollContainer).maxHeight;
-      if (/\d+$/.test(maxHeightString)) { // e.g: 50px
+      if (/\d+px$/.test(maxHeightString)) { // e.g: 50px
         maxHeight = parseInt(maxHeightString);
       } else if (/\d+%$/.test(maxHeightString)) { // e.g: 50%
         const percent = maxHeightString.substr(0, maxHeightString.length - 1);

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -7,7 +7,7 @@ import insertRangeBefore from '../utils/insert-range-before';
 import objectAt from '../utils/object-at';
 import roundTo from '../utils/round-to';
 
-import estimateElementHeight from '../../utils/element/estimate-element-height';
+import { estimateElementHeight, estimateElementMaxHeight } from '../../utils/element/estimate-element-height';
 
 import { assert, stripInProduction } from 'vertical-collection/-debug/helpers';
 
@@ -217,13 +217,7 @@ export default class Radar {
 
     let maxHeight = 0;
     if (scrollContainer instanceof Element) {
-      const maxHeightString = window.getComputedStyle(scrollContainer).maxHeight;
-      if (/\d+px$/.test(maxHeightString)) { // e.g: 50px
-        maxHeight = parseInt(maxHeightString);
-      } else if (/\d+%$/.test(maxHeightString)) { // e.g: 50%
-        const percent = maxHeightString.substr(0, maxHeightString.length - 1);
-        maxHeight = scrollContainer.parentElement.offsetHeight * (percent / 100.0);
-      }
+      maxHeight = estimateElementMaxHeight(scrollContainer);
     }
 
     maxHeight = isNaN(maxHeight) ? 0 : maxHeight;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -218,9 +218,9 @@ export default class Radar {
     let maxHeight = 0;
     if (scrollContainer instanceof Element) {
       const maxHeightString = window.getComputedStyle(scrollContainer).maxHeight;
-      if (/\d+$/.test(maxHeightString)) {
+      if (/\d+$/.test(maxHeightString)) { // e.g: 50px
         maxHeight = parseInt(maxHeightString);
-      } else if (/\d+%$/.test(maxHeightString)) {
+      } else if (/\d+%$/.test(maxHeightString)) { // e.g: 50%
         const percent = maxHeightString.substr(0, maxHeightString.length - 1);
         maxHeight = scrollContainer.parentElement.offsetHeight * (percent / 100.0);
       }

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -220,6 +220,9 @@ export default class Radar {
       const maxHeightString = window.getComputedStyle(scrollContainer).maxHeight;
       if (/\d+$/.test(maxHeightString)) {
         maxHeight = parseInt(maxHeightString);
+      } else if (/\d+%$/.test(maxHeightString)) {
+        const percent = maxHeightString.substr(0, maxHeightString.length - 1);
+        maxHeight = scrollContainer.parentElement.offsetHeight * (percent / 100.0);
       }
     }
 

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -215,7 +215,14 @@ export default class Radar {
       height: scrollContainerHeight
     } = scrollContainer.getBoundingClientRect();
 
-    let maxHeight = scrollContainer instanceof Element ? parseInt(window.getComputedStyle(scrollContainer).maxHeight) : 0;
+    let maxHeight = 0;
+    if (scrollContainer instanceof Element) {
+      const maxHeightString = window.getComputedStyle(scrollContainer).maxHeight;
+      if (/\d+$/.test(maxHeightString)) { // example: 50%
+        maxHeight = parseInt(maxHeightString);
+      }
+    }
+
     maxHeight = isNaN(maxHeight) ? 0 : maxHeight;
 
     this._estimateHeight = typeof estimateHeight === 'string' ? estimateElementHeight(itemContainer, estimateHeight) : estimateHeight;

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -218,7 +218,7 @@ export default class Radar {
     let maxHeight = 0;
     if (scrollContainer instanceof Element) {
       const maxHeightString = window.getComputedStyle(scrollContainer).maxHeight;
-      if (/\d+$/.test(maxHeightString)) { // example: 50%
+      if (/\d+$/.test(maxHeightString)) {
         maxHeight = parseInt(maxHeightString);
       }
     }

--- a/addon/-private/index.js
+++ b/addon/-private/index.js
@@ -1,7 +1,7 @@
 export { default as keyForItem } from './ember-internals/utils/key-for-item';
 export { SUPPORTS_INVERSE_BLOCK } from './ember-internals/compatibility';
 
-export { default as estimateElementHeight } from './utils/element/estimate-element-height';
+export { estimateElementHeight } from './utils/element/estimate-element-height';
 export { default as closestElement } from './utils/element/closest';
 
 export { default as DynamicRadar } from './data-view/radar/dynamic-radar';

--- a/addon/-private/utils/element/estimate-element-height.js
+++ b/addon/-private/utils/element/estimate-element-height.js
@@ -1,24 +1,48 @@
 import { assert } from 'vertical-collection/-debug/helpers';
 
-export default function estimateElementHeight(element, fallbackHeight) {
+export function estimateElementHeight(element, fallbackHeight) {
   assert(`You called estimateElement height without a fallbackHeight`, fallbackHeight);
   assert(`You called estimateElementHeight without an element`, element);
 
   if (fallbackHeight.indexOf('%') !== -1) {
-    let parentHeight = element.getBoundingClientRect().height;
-    let per = parseFloat(fallbackHeight);
-
-    return Math.max(per * parentHeight / 100, 1);
+    return Math.max(getPercentageHeight(element, fallbackHeight), 1);
   }
 
   if (fallbackHeight.indexOf('em') !== -1) {
-    const fontSizeElement = fallbackHeight.indexOf('rem') !== -1 ? document.body : element;
-    const fontSize = window.getComputedStyle(fontSizeElement).getPropertyValue('font-size');
-    const estimateHeight = parseFloat(fallbackHeight) * parseFloat(fontSize);
-
-    return Math.max(estimateHeight, 1);
+    return Math.max(getEmHeight(element, fallbackHeight), 1);
   }
 
   // px or no units
   return Math.max(parseInt(fallbackHeight, 10), 1);
+}
+
+/**
+ * Returns estimated max height of an element.
+ */
+export function estimateElementMaxHeight(element) {
+  const maxHeightString = window.getComputedStyle(element).maxHeight;
+  if (maxHeightString.indexOf('%') !== -1) {
+    return getPercentageHeight(element, maxHeightString);
+  }
+
+  if (maxHeightString.indexOf('em') !== -1) {
+    return getEmHeight(element, maxHeightString);
+  }
+
+  // px or no units
+  return parseInt(maxHeightString, 10);
+}
+
+function getPercentageHeight(element, fallbackHeight) {
+  let parentHeight = element.getBoundingClientRect().height;
+  let per = parseFloat(fallbackHeight);
+
+  return per * parentHeight / 100.0;
+}
+
+function getEmHeight(element, fallbackHeight) {
+  const fontSizeElement = fallbackHeight.indexOf('rem') !== -1 ? document.body : element;
+  const fontSize = window.getComputedStyle(fontSizeElement).getPropertyValue('font-size');
+
+  return parseFloat(fallbackHeight) * parseFloat(fontSize);
 }


### PR DESCRIPTION
In javascript `parseInt (100%)` does not return NaN. It returns number 100 instead (yay javascript!).

This PR fixes the logic to get max height in radar with percentage. Since `max-height` percentage represents the maximum amount of space that an element can have relative to its parent, we should extract the `maxHeight` in pixel number from parent's relative height. 

This PR alsofixes https://github.com/html-next/vertical-collection/issues/127

@runspired @pzuraq 
