### PR TITLE
Correct checking calculateStartingIndex

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -272,7 +272,7 @@ function calculateStartingIndex(items, idForFirstItem, key, renderFromLast) {
 
   let startingIndex = 0;
 
-  if (idForFirstItem !== null) {
+  if (idForFirstItem !== undefined && idForFirstItem !== null) {
     for (let i = 0; i < totalItems; i++) {
       if (keyForItem(objectAt(items, i), key, i) === idForFirstItem) {
         startingIndex = i;

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -272,7 +272,7 @@ function calculateStartingIndex(items, idForFirstItem, key, renderFromLast) {
 
   let startingIndex = 0;
 
-  if (idForFirstItem !== undefined) {
+  if (idForFirstItem !== null) {
     for (let i = 0; i < totalItems; i++) {
       if (keyForItem(objectAt(items, i), key, i) === idForFirstItem) {
         startingIndex = i;


### PR DESCRIPTION
I have a list of 10k items and I see in my log that the `objectAt` is called 10k time at the beginning. 

This happens because the default value of `idForFirstItem` is null (https://github.com/html-next/vertical-collection/blob/master/addon/components/vertical-collection/component.js#L75) but when we do checking logic, we check `idForFirstItem !== undefined `. This inconsistency makes the `if` condition true and the loop inside `if` is executed. This PR fixes that. 

@runspired @pzuraq 