### PR TITLE
(bugfix): Fix incorrect occluded content height.

### DIFF
--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -342,10 +342,10 @@ export default class Radar {
     const afterItemsText = totalItemsAfter === 1 ? 'item' : 'items';
 
     // Set padding element heights, unset itemContainer's minHeight
-    _occludedContentBefore.element.style.height = `${renderedTotalBefore}px`;
+    _occludedContentBefore.element.style.height = `${Math.max(renderedTotalBefore, 0)}px`;
     _occludedContentBefore.element.innerHTML = totalItemsBefore > 0 ? `And ${totalItemsBefore} ${beforeItemsText} before` : '';
 
-    _occludedContentAfter.element.style.height = `${renderedTotalAfter}px`;
+    _occludedContentAfter.element.style.height = `${Math.max(renderedTotalAfter, 0)}px`;
     _occludedContentAfter.element.innerHTML = totalItemsAfter > 0 ? `And ${totalItemsAfter} ${afterItemsText} after` : '';
 
     itemContainer.style.minHeight = '';


### PR DESCRIPTION
Sometimes while scrolling a list in a table, I see some open empty space at the top and bottom of the list (see image). After opening the inspection tab, I see height of `occluded-content` is non-zero even though there is no item before/after the list. 

Debugging in the code reveals that the occluded content style height is set to random number when `renderedTotalBefore` is negative. 

https://github.com/html-next/vertical-collection/blob/master/addon/-private/data-view/radar/radar.js#L345 

Since `renderedTotalBefore` is a computed floating number, it's possible that it could be close to 0 and negative. This PR fixes that by using 0 value when `renderedTotalBefore` is negative.

![screen shot 2017-09-05 at 11 28 09 am copy](https://user-images.githubusercontent.com/11281370/30076622-5245f596-922e-11e7-92e1-e6affb609060.png)
