### PR TITLE
[BREAKING] make default `containerSelector="body"`

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -44,17 +44,15 @@ const VerticalCollection = Component.extend({
   shouldRecycle: true,
 
   /*
-   * A selector string that will select the element from
-   * which to calculate the viewable height and needed offsets.
+   * A selector string that will select the closest parent element
+   * to which to attach the `scroll` event handler and from which
+   * to calculate the viewable height and needed offsets.
    *
-   * This element will also have the `scroll` event handler added to it.
+   * To set this to the component's immediate parent element, use '*'
    *
-   * Usually this element will be the component's immediate parent element,
-   * if so, you can leave this null.
-   *
-   * Set this to "body" to scroll the entire web page.
+   * @default 'body'
    */
-  containerSelector: null,
+  containerSelector: 'body',
 
   // –––––––––––––– Performance Tuning
   /*

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -1,9 +1,9 @@
 <div class="table-wrapper dark">
   {{#vertical-collection model
+    containerSelector=".table-wrapper"
     estimateHeight=50
     bufferSize=5
-
-    as |item index|}}
+  as |item index|}}
     {{number-slide item=item index=index}}
   {{/vertical-collection}}
 </div>

--- a/tests/dummy/app/routes/examples/flexible-layout/template.hbs
+++ b/tests/dummy/app/routes/examples/flexible-layout/template.hbs
@@ -5,6 +5,7 @@
       {{!- BEGIN-SNIPPET flexible-layout-example }}
         <div class="table-wrapper dark">
           {{#vertical-collection model.numbers
+            containerSelector="*"
             estimateHeight=270
             firstReached="loadAbove"
             lastReached="loadBelow"

--- a/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
@@ -5,15 +5,13 @@
       {{!- BEGIN-SNIPPET infinite-scroll-example }}
         <div class="table-wrapper dark">
           {{#vertical-collection model.numbers
+            containerSelector="*"
             estimateHeight=90
             staticHeight=true
             bufferSize=5
-
             firstReached="loadAbove"
             lastReached="loadBelow"
-
-            as |item index|
-          }}
+          as |item index| }}
             {{number-slide item=item index=index}}
           {{/vertical-collection}}
         </div>

--- a/tests/dummy/app/routes/examples/reduce-debug/template.hbs
+++ b/tests/dummy/app/routes/examples/reduce-debug/template.hbs
@@ -4,6 +4,7 @@
           <h3>Demo</h3>
           <div class="table-wrapper dark">
             {{#vertical-collection
+              containerSelector="*"
               items=model.filtered
               defaultHeight=270
               useContentProxy=false

--- a/tests/dummy/app/routes/settings/snippets/defaults.js
+++ b/tests/dummy/app/routes/settings/snippets/defaults.js
@@ -68,9 +68,10 @@ export default
 
 // scroll setup
 
-  // Selector for the scrollContainer. Defaults to
-  // the immediate parent of the collection if null.
-  containerSelector: null
+  // Selector for the scrollContainer. Defaults to "body"
+  // to select the immediate parent element of the collection
+  // use "*" or a mroe specific selector if available.
+  containerSelector: "body"
 }
 /* !- END-SNIPPET vertical-collection-defaults-example */
 ;

--- a/tests/dummy/app/routes/settings/snippets/defaults.js
+++ b/tests/dummy/app/routes/settings/snippets/defaults.js
@@ -68,10 +68,10 @@ export default
 
 // scroll setup
 
-  // Selector for the scrollContainer. Defaults to "body"
+  // Selector for the scrollContainer. Defaults to 'body',
   // to select the immediate parent element of the collection
   // use "*" or a more specific selector if available.
-  containerSelector: "body"
+  containerSelector: 'body'
 }
 /* !- END-SNIPPET vertical-collection-defaults-example */
 ;

--- a/tests/dummy/app/routes/settings/snippets/defaults.js
+++ b/tests/dummy/app/routes/settings/snippets/defaults.js
@@ -70,7 +70,7 @@ export default
 
   // Selector for the scrollContainer. Defaults to "body"
   // to select the immediate parent element of the collection
-  // use "*" or a mroe specific selector if available.
+  // use "*" or a more specific selector if available.
   containerSelector: "body"
 }
 /* !- END-SNIPPET vertical-collection-defaults-example */

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -80,6 +80,7 @@ export const scenariosFor = mergeScenarioGenerators(
 export const standardTemplate = hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
     {{#vertical-collection items
+      containerSelector="*"
       estimateHeight=(either-or estimateHeight 20)
       staticHeight=staticHeight
       bufferSize=(either-or bufferSize 0)

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -63,6 +63,7 @@ testScenarios(
   hbs`
     <div style="height: 100px; font-size: 10px;" class="scrollable">
       {{#vertical-collection items
+        containerSelector="*"
         estimateHeight="2em"
         staticHeight=staticHeight
         bufferSize=0
@@ -88,6 +89,7 @@ testScenarios(
   hbs`
     <div style="height: 100px; font-size: 10px;" class="scrollable">
       {{#vertical-collection items
+        containerSelector="*"
         estimateHeight="2rem"
         staticHeight=staticHeight
         bufferSize=0
@@ -113,6 +115,7 @@ testScenarios(
   hbs`
     <div style="height: 100px;" class="scrollable">
       {{#vertical-collection items
+        containerSelector="*"
         estimateHeight="66%"
         staticHeight=staticHeight
         bufferSize=0
@@ -138,6 +141,7 @@ testScenarios(
   hbs`
     <div style="height: 100px; font-size: 10px;" class="scrollable">
       {{#vertical-collection items
+        containerSelector="*"
         estimateHeight="2em"
         staticHeight=staticHeight
         bufferSize=0
@@ -305,6 +309,7 @@ test('The collection renders the initialRenderCount correctly', async function(a
   this.render(hbs`
     <div style="height: 500px; width: 500px;" class="scrollable">
       {{#vertical-collection items
+        containerSelector="*"
         estimateHeight=50
         initialRenderCount=1
         as |item i|
@@ -335,6 +340,7 @@ test('The collection renders the initialRenderCount correctly if idForFirstItem 
   this.render(hbs`
     <div style="height: 500px; width: 500px;" class="scrollable">
       {{#vertical-collection items
+        containerSelector="*"
         estimateHeight=50
         initialRenderCount=1
         idForFirstItem="20"
@@ -367,6 +373,7 @@ test('The collection renders the initialRenderCount correctly if the count is mo
   this.render(hbs`
     <div style="height: 500px; width: 500px;" class="scrollable">
       {{#vertical-collection items
+        containerSelector="*"
         estimateHeight=50
         initialRenderCount=5
         as |item i|

--- a/tests/integration/modern-ember-test.js
+++ b/tests/integration/modern-ember-test.js
@@ -17,6 +17,7 @@ if (SUPPORTS_INVERSE_BLOCK) {
 
     this.render(hbs`
       {{#vertical-collection items
+        containerSelector="*"
         estimateHeight=20
         staticHeight=true
       }}

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -433,9 +433,9 @@ testScenarios(
     <div style="height: 200px; width: 200px;" class="scroll-parent scrollable">
       <div style="height: 400px; width: 100px;" class="scroll-child scrollable">
         {{#vertical-collection items
+          containerSelector="*"
           estimateHeight=20
           bufferSize=0
-
           as |item i|}}
           <div class="vertical-item" style="height:40px;">
             {{item.number}} {{i}}


### PR DESCRIPTION
This PR changes the default behavior of the collection from expecting the immediate parent div to have scrollable styles defined to expecting that the user intends to rely on the scrolling of the viewport.

To restore the previous default behavior for the collection, set `containerSelector="*"`.