### PR TITLE
feat(scaling): Makes the collection work with scaling

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -3,6 +3,7 @@ import { DEBUG } from '@glimmer/env';
 import Radar from './radar';
 import SkipList from '../skip-list';
 import roundTo from '../utils/round-to';
+import getScaledClientRect from '../../utils/element/get-scaled-client-rect';
 
 export default class DynamicRadar extends Radar {
   constructor(parentToken, options) {
@@ -116,8 +117,10 @@ export default class DynamicRadar extends Radar {
   _measure(measureLimit = null) {
     const {
       orderedComponents,
+      skipList,
+
       _occludedContentBefore,
-      skipList
+      _transformScale
     } = this;
 
     const numToMeasure = measureLimit !== null ? measureLimit : orderedComponents.length;
@@ -132,14 +135,14 @@ export default class DynamicRadar extends Radar {
       const {
         top: currentItemTop,
         height: currentItemHeight
-      } = currentItem.getBoundingClientRect();
+      } = getScaledClientRect(currentItem, _transformScale);
 
       let margin;
 
       if (previousItem !== undefined) {
-        margin = currentItemTop - previousItem.getBoundingClientRect().bottom;
+        margin = currentItemTop - getScaledClientRect(previousItem, _transformScale).bottom;
       } else {
-        margin = currentItemTop - _occludedContentBefore.getBoundingClientRect().bottom;
+        margin = currentItemTop - getScaledClientRect(_occludedContentBefore, _transformScale).bottom;
       }
 
       const itemDelta = skipList.set(itemIndex, roundTo(currentItemHeight + margin));

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -267,11 +267,15 @@ export default class Radar {
     const scrollContainerOffsetHeight = _scrollContainer.offsetHeight;
     const { height: scrollContainerRenderedHeight } = _scrollContainer.getBoundingClientRect();
 
-    // Represents the opposite of the scale, if any, applied to the collection. Check for equality
-    // to guard against floating point errors and divide by zero (both should be zero if one is)
-    const transformScale = scrollContainerOffsetHeight !== scrollContainerRenderedHeight
-      ? scrollContainerOffsetHeight / scrollContainerRenderedHeight
-      : 1;
+    let transformScale;
+
+    // transformScale represents the opposite of the scale, if any, applied to the collection. Check for equality
+    // to guard against floating point errors, and check to make sure we're not dividing by zero (default to scale 1 if so)
+    if (scrollContainerOffsetHeight === scrollContainerRenderedHeight || scrollContainerRenderedHeight === 0) {
+      transformScale = 1;
+    } else {
+      transformScale = scrollContainerOffsetHeight / scrollContainerRenderedHeight;
+    }
 
     const { top: scrollContentTop } = getScaledClientRect(_occludedContentBefore, transformScale);
     const { top: scrollContainerTop } = getScaledClientRect(_scrollContainer, transformScale);

--- a/addon/-private/utils/element/get-scaled-client-rect.js
+++ b/addon/-private/utils/element/get-scaled-client-rect.js
@@ -1,0 +1,15 @@
+export default function getScaledClientRect(element, scale) {
+  const rect = element.getBoundingClientRect();
+
+  if (scale === 1) {
+    return rect;
+  }
+
+  const scaled = {};
+
+  for (let key in rect) {
+    scaled[key] = rect[key] * scale;
+  }
+
+  return scaled;
+}

--- a/tests/helpers/measurement.js
+++ b/tests/helpers/measurement.js
@@ -1,11 +1,11 @@
 export function containerHeight(itemContainer) {
-  return itemContainer.getBoundingClientRect().height;
+  return itemContainer.offsetHeight;
 }
 
 export function paddingBefore(itemContainer) {
-  return itemContainer.firstElementChild.getBoundingClientRect().height;
+  return itemContainer.firstElementChild.offsetHeight;
 }
 
 export function paddingAfter(itemContainer) {
-  return itemContainer.lastElementChild.getBoundingClientRect().height;
+  return itemContainer.lastElementChild.offsetHeight;
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -14,12 +14,6 @@
     <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
-    <!-- <style>
-      #ember-testing {
-        transform: scale(1.0);
-      }
-    </style> -->
-
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>

--- a/tests/index.html
+++ b/tests/index.html
@@ -14,11 +14,11 @@
     <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
-    <style>
+    <!-- <style>
       #ember-testing {
         transform: scale(1.0);
       }
-    </style>
+    </style> -->
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -1,4 +1,6 @@
 import { moduleForComponent } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
 import {
   find,
   scrollTo
@@ -130,5 +132,32 @@ testScenarios(
     assert.equal(find('.scrollable').scrollTop, 300, 'scrollTop set to correct value');
     assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '30 10', 'the first rendered item is correct');
     assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '39 19', 'the last rendered item is correct');
+  }
+);
+
+testScenarios(
+  'The collection renders correctly when scaled',
+  dynamicSimpleScenarioFor(getNumbers(0, 100)),
+
+  hbs`
+    <div style="transform: scale(0.333333)">
+      <div style="height: 100px" class="scrollable">
+        {{#vertical-collection items
+          estimateHeight=20
+          bufferSize=0
+
+          as |item i|}}
+          <vertical-item style="height: 30px">
+            {{item.number}} {{i}}
+          </vertical-item>
+        {{/vertical-collection}}
+      </div>
+    </div>
+  `,
+
+  async function(assert) {
+    await scrollTo('.scrollable', 0, 150);
+
+    assert.equal(paddingBefore(find('.scrollable')), 150, 'Rendered correct number of items');
   }
 );

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -14,6 +14,7 @@ import {
 } from 'dummy/tests/helpers/test-scenarios';
 
 import { prepend, append } from 'dummy/tests/helpers/array';
+import { paddingBefore } from 'dummy/tests/helpers/measurement';
 
 moduleForComponent('vertical-collection', 'Integration | Scroll Tests', {
   integration: true
@@ -417,13 +418,10 @@ testScenarios(
     // Occlude one item
     await scrollTo('.scrollable', 0, 38);
 
-    const tableTop = find('table').getBoundingClientRect().top;
-
     const row = find('tr:first-of-type');
-    const rowTop = row.getBoundingClientRect().top;
 
     assert.equal(row.textContent.replace(/\s/g, ''), '11', 'correct first row is rendered');
-    assert.equal(rowTop - tableTop, 37, 'first row offset is correct');
+    assert.equal(paddingBefore(find('tbody')), 37, 'first row offset is correct');
   }
 );
 


### PR DESCRIPTION
When used in a container with `transform: scale`, the collection would break due to measurements being off. For example, we would measure an item that was normally 20px to be scaled by say 10px, and then we would render the measured value, which would be scaled again down to 5px. Lots of small bugs popped up due to this.

This PR adds a `getScaledClientRect` helper which accepts a scale value and element and returns the client rect scaled to the correct size. We determine the scale value in `updateConstants` by comparing the client rect of the scroll container to it's offsetHeight.

This strategy does not account for cases where, for instance, the item container is scaled, but the scroll container isn't. We can probably guard against these cases in debug assertions.