### PR TITLE
bugfix(setup): Disable interaction before start

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -195,23 +195,33 @@ export default class DynamicRadar extends Radar {
   }
 
   prepend(numPrepended) {
+    if (this._started === false) {
+      return;
+    }
+
     super.prepend(numPrepended);
 
     this.skipList.prepend(numPrepended);
   }
 
   append(numAppended) {
+    if (this._started === false) {
+      return;
+    }
+
     super.append(numAppended);
 
     this.skipList.append(numAppended);
   }
 
   reset() {
+    if (this._started === false) {
+      return;
+    }
+
     super.reset();
 
-    if (this.skipList !== null) {
-      this.skipList.reset(this.totalItems);
-    }
+    this.skipList.reset(this.totalItems);
   }
 
   /*

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -110,9 +110,10 @@ export default class Radar {
   start() {
     let { startingIndex } = this;
 
-    if (startingIndex !== 0) {
-      this._updateConstants();
+    // Run initial measurements and setup initial state, e.g. skipList in dynamic radar
+    this._updateConstants();
 
+    if (startingIndex !== 0) {
       const {
         totalItems,
         renderFromLast,
@@ -437,6 +438,10 @@ export default class Radar {
   }
 
   prepend(numPrepended) {
+    if (this._started === false) {
+      return;
+    }
+
     this._prevFirstItemIndex += numPrepended;
     this._prevLastItemIndex += numPrepended;
 
@@ -450,10 +455,18 @@ export default class Radar {
   }
 
   append() {
+    if (this._started === false) {
+      return;
+    }
+
     this._lastReached = false;
   }
 
   reset() {
+    if (this._started === false) {
+      return;
+    }
+
     this._firstReached = false;
     this._lastReached = false;
     this._didReset = true;

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -417,7 +417,7 @@ testScenarios(
 );
 
 testScenarios(
-  'The collection renders in the correctly when starting offscreen',
+  'The collection renders correctly when starting offscreen',
   scenariosFor(getNumbers(0, 100)),
 
   hbs`

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -468,3 +468,22 @@ testScenarios(
     assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '49 49', 'the last item in the list should be rendered');
   }
 );
+
+testScenarios(
+  'The collection does not allow interaction before being setup',
+  scenariosFor(getNumbers(20, 100)),
+  standardTemplate,
+
+  false, // Run test function before render
+  async function(assert) {
+    assert.expect(2);
+
+    prepend(this, getNumbers(10, 10));
+    prepend(this, getNumbers(0, 10));
+
+    await waitForRender();
+
+    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '0 0', 'Rendered correct number of items');
+    assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '9 9', 'Rendered correct number of items');
+  }
+);


### PR DESCRIPTION
Some users are reporting the collection is able to get into a bad state where prepends/appends happen before setup has fully been completed. This could if the array is immediately replaced with another array before setup has finished.

This PR disables all interactions with the collection before it has been initialized. Modifying state before first render doesn't particularly make sense anyways, so this is just guarding against a case that shouldn't be happening.

## Alternatives

We could warn or error if this occurs, in most cases this could probably be fixed by changes to user code. I do think there may be legitimate use cases, but since the failure reported could not be reproduced (mxz phoned it in) I couldn't say in that case.

In particular this could be problematic in the corner case where `initialRenderCount` is used, since it won't pick up any changes to the items in between when `vertical-collection` is initialized and first render. This could potentially confuse users who would expect the initial render to reflect the updated array.