### PR TITLE
[BREAKING] refactor(tag): Makes vertical-collection tagless

### DIFF
--- a/addon/-debug/edge-visualization/debug-mixin.js
+++ b/addon/-debug/edge-visualization/debug-mixin.js
@@ -61,7 +61,7 @@ export default Mixin.create({
     // check item defaults
     assert(`You must supply at least one item to the collection to debug it's CSS.`, this.get('items.length'));
 
-    let element = radar.itemContainer.firstElementChild;
+    let element = radar._itemContainer.firstElementChild;
 
     styles = window.getComputedStyle(element);
 

--- a/addon/-debug/edge-visualization/visualization.js
+++ b/addon/-debug/edge-visualization/visualization.js
@@ -40,14 +40,10 @@ export default class Visualization {
   }
 
   styleViewport() {
-    const {
-      itemContainer,
-      scrollContainer
-    } = this.radar;
-    this.container.style.height = `${scrollContainer.getBoundingClientRect().height}px`;
+    const { _scrollContainer } = this.radar;
+    this.container.style.height = `${_scrollContainer.getBoundingClientRect().height}px`;
 
-    applyVerticalStyles(this.scrollContainer, scrollContainer.getBoundingClientRect());
-    applyVerticalStyles(this.itemContainer, itemContainer.getBoundingClientRect());
+    applyVerticalStyles(this.scrollContainer, _scrollContainer.getBoundingClientRect());
     applyVerticalStyles(this.screen, Container.getBoundingClientRect());
   }
 

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -5,8 +5,8 @@ import SkipList from '../skip-list';
 import roundTo from '../utils/round-to';
 
 export default class DynamicRadar extends Radar {
-  constructor(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle) {
-    super(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle);
+  constructor(parentToken, options) {
+    super(parentToken, options);
 
     this._firstItemIndex = 0;
     this._lastItemIndex = 0;
@@ -116,7 +116,7 @@ export default class DynamicRadar extends Radar {
   _measure(measureLimit = null) {
     const {
       orderedComponents,
-      itemContainer,
+      _occludedContentBefore,
       totalBefore,
       skipList
     } = this;
@@ -140,7 +140,7 @@ export default class DynamicRadar extends Radar {
       if (previousItem !== undefined) {
         margin = currentItemTop - previousItem.getBoundingClientRect().bottom;
       } else {
-        margin = currentItemTop - itemContainer.getBoundingClientRect().top - totalBefore;
+        margin = currentItemTop - _occludedContentBefore.getBoundingClientRect().top - totalBefore;
       }
 
       const itemDelta = skipList.set(itemIndex, roundTo(currentItemHeight + margin));

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -117,7 +117,6 @@ export default class DynamicRadar extends Radar {
     const {
       orderedComponents,
       _occludedContentBefore,
-      totalBefore,
       skipList
     } = this;
 
@@ -140,7 +139,7 @@ export default class DynamicRadar extends Radar {
       if (previousItem !== undefined) {
         margin = currentItemTop - previousItem.getBoundingClientRect().bottom;
       } else {
-        margin = currentItemTop - _occludedContentBefore.getBoundingClientRect().top - totalBefore;
+        margin = currentItemTop - _occludedContentBefore.getBoundingClientRect().bottom;
       }
 
       const itemDelta = skipList.set(itemIndex, roundTo(currentItemHeight + margin));

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -3,8 +3,8 @@ import { DEBUG } from '@glimmer/env';
 import Radar from './radar';
 
 export default class StaticRadar extends Radar {
-  constructor(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle) {
-    super(parentToken, initialItems, initialRenderCount, startingIndex, shouldRecycle);
+  constructor(parentToken, options) {
+    super(parentToken, options);
 
     this._firstItemIndex = 0;
     this._lastItemIndex = 0;

--- a/addon/styles/app.css
+++ b/addon/styles/app.css
@@ -1,11 +1,3 @@
-/* includes legacy support for older tagNames */
-vertical-collection {
-  display: block;
-  width: 100%;
-  min-height: 100%;
-  position: relative;
-}
-
 occluded-content {
   display: block;
   position: relative;

--- a/tests/dummy/app/routes/examples/dbmon/template.hbs
+++ b/tests/dummy/app/routes/examples/dbmon/template.hbs
@@ -6,19 +6,20 @@
         {{!- BEGIN-SNIPPET dbmon-example }}
           <div class="table-wrapper">
             <table class="table table-striped latest-data">
-              {{#vertical-collection model.databases
-                containerSelector=".table-wrapper"
-                tagName="tbody"
-                key="id"
+              <tbody>
+                {{#vertical-collection model.databases
+                  containerSelector=".table-wrapper"
+                  key="id"
 
-                estimateHeight=37
-                staticHeight=true
-                bufferSize=5
+                  estimateHeight=37
+                  staticHeight=true
+                  bufferSize=5
 
-                as |db|
-              }}
-                {{examples/dbmon/components/dbmon-row tagName="tr" db=db}}
-              {{/vertical-collection}}
+                  as |db|
+                }}
+                  {{examples/dbmon/components/dbmon-row tagName="tr" db=db}}
+                {{/vertical-collection}}
+              </tbody>
             </table>
           </div>
         {{!- END-SNIPPET }}

--- a/tests/dummy/app/routes/settings/snippets/defaults.js
+++ b/tests/dummy/app/routes/settings/snippets/defaults.js
@@ -2,7 +2,7 @@ export default
 /* !- BEGIN-SNIPPET vertical-collection-defaults-example */
 {
 // basics
-  tagName: 'vertical-collection',
+  tagName: '',
 
 // required
 
@@ -68,9 +68,11 @@ export default
 
 // scroll setup
 
-  // Selector for the scrollContainer. Defaults to
-  // the immediate parent of the collection if null.
-  containerSelector: null
+  // Selector for the scrollContainer. The collection
+  // will traverse its ancestry to find the first element
+  // that matches the selector. Defaults to '*', which
+  // will match the immediate parent of the collection.
+  containerSelector: '*'
 }
 /* !- END-SNIPPET vertical-collection-defaults-example */
 ;

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -316,10 +316,8 @@ test('The collection renders the initialRenderCount correctly', async function(a
     </div>
   `);
 
-  requestAnimationFrame(() => {
-    assert.equal(findAll('vertical-item').length, 1, 'correct number of items rendered on initial pass');
-    assert.equal(find('vertical-item').textContent.trim(), '0 0', 'correct item rendered');
-  });
+  assert.equal(findAll('vertical-item').length, 1, 'correct number of items rendered on initial pass');
+  assert.equal(find('vertical-item').textContent.trim(), '0 0', 'correct item rendered');
 
   await wait();
 
@@ -348,10 +346,8 @@ test('The collection renders the initialRenderCount correctly if idForFirstItem 
     </div>
   `);
 
-  requestAnimationFrame(() => {
-    assert.equal(findAll('vertical-item').length, 1, 'correct number of items rendered on initial pass');
-    assert.equal(find('vertical-item').textContent.trim(), '20 20', 'correct item rendered');
-  });
+  assert.equal(findAll('vertical-item').length, 1, 'correct number of items rendered on initial pass');
+  assert.equal(find('vertical-item').textContent.trim(), '20 20', 'correct item rendered');
 
   await wait();
 

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -27,7 +27,7 @@ testScenarios(
   async function(assert) {
     assert.expect(2);
 
-    const itemContainer = find('vertical-collection');
+    const itemContainer = find('.scrollable');
     assert.equal(paddingBefore(itemContainer), 0, 'itemContainer padding is correct on initial render');
 
     find('.vertical-item:first-of-type').style.height = '50px';
@@ -46,7 +46,7 @@ testScenarios(
   async function(assert) {
     assert.expect(3);
 
-    const itemContainer = find('vertical-collection');
+    const itemContainer = find('.scrollable');
 
     assert.equal(paddingAfter(itemContainer), 200, 'itemContainer padding is correct on initial render');
 
@@ -71,7 +71,7 @@ testScenarios(
 
     await scrollTo('.scrollable', 0, 400);
 
-    const itemContainer = find('vertical-collection');
+    const itemContainer = find('.scrollable');
 
     // Floats aren't perfect, neither is browser rendering/measuring, but any subpixel errors
     // should be amplified to the point where they are very noticeable at this point, so rounding
@@ -105,7 +105,7 @@ testScenarios(
 
     assert.equal(find('.scrollable').scrollTop, 420, 'scrollTop set to correct value');
 
-    const itemContainer = find('vertical-collection');
+    const itemContainer = find('.scrollable');
     assert.equal(paddingBefore(itemContainer), 360, 'Occluded content has the correct height before');
     assert.equal(paddingAfter(itemContainer), 260, 'Occluded content has the correct height after');
   }

--- a/tests/integration/modern-ember-test.js
+++ b/tests/integration/modern-ember-test.js
@@ -15,17 +15,19 @@ if (SUPPORTS_INVERSE_BLOCK) {
     this.set('items', []);
 
     this.render(hbs`
-      {{#vertical-collection items
-        estimateHeight=20
-        staticHeight=true
-      }}
-        {{else}}
-          Foobar
-      {{/vertical-collection}}
+      <div class="scrollable">
+        {{#vertical-collection items
+          estimateHeight=20
+          staticHeight=true
+        }}
+          {{else}}
+            Foobar
+        {{/vertical-collection}}
+      </div>
     `);
 
     await wait();
 
-    assert.equal(find('vertical-collection').textContent.indexOf('Foobar') !== -1, true);
+    assert.equal(find('.scrollable').textContent.indexOf('Foobar') !== -1, true);
   });
 }

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -14,7 +14,7 @@ import {
 } from 'dummy/tests/helpers/test-scenarios';
 
 import { prepend, append, emptyArray, replaceArray, move } from 'dummy/tests/helpers/array';
-import { paddingBefore, containerHeight } from 'dummy/tests/helpers/measurement';
+import { paddingBefore, paddingAfter } from 'dummy/tests/helpers/measurement';
 
 moduleForComponent('vertical-collection', 'Integration | Mutation Tests', {
   integration: true
@@ -26,22 +26,23 @@ testScenarios(
   standardTemplate,
 
   async function(assert) {
-    assert.expect(8);
+    assert.expect(10);
 
     const scrollContainer = find('.scrollable');
-    const itemContainer = find('vertical-collection');
 
     assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '0 0', 'first item rendered correctly before prepend');
     assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '9 9', 'last item rendered correctly before prepnd');
     assert.equal(scrollContainer.scrollTop, 0, 'scrollTop is correct before prepend');
-    assert.equal(containerHeight(itemContainer), 2000, 'itemContainer height is correct before prepend');
+    assert.equal(paddingBefore(scrollContainer), 0, 'padding before is correct before prepend');
+    assert.equal(paddingAfter(scrollContainer), 1800, 'padding after is correct before prepend');
 
     await prepend(this, getNumbers(-20, 20));
 
     assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '0 20', 'first item rendered correctly after prepend');
     assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '9 29', 'last item rendered correctly after prepend');
     assert.equal(scrollContainer.scrollTop, 400, 'scrollTop is correct after prepend');
-    assert.equal(containerHeight(itemContainer), 2400, 'itemContainer height is correct after prepend');
+    assert.equal(paddingBefore(scrollContainer), 400, 'padding before is correct after prepend');
+    assert.equal(paddingAfter(scrollContainer), 1800, 'padding after is correct after prepend');
   }
 );
 
@@ -51,22 +52,23 @@ testScenarios(
   standardTemplate,
 
   async function(assert) {
-    assert.expect(8);
+    assert.expect(10);
 
     const scrollContainer = find('.scrollable');
-    const itemContainer = find('vertical-collection');
 
     assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '0 0', 'first item rendered correctly before append');
     assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '9 9', 'last item rendered correctly before append');
     assert.equal(scrollContainer.scrollTop, 0, 'scrollTop is correct before append');
-    assert.equal(containerHeight(itemContainer), 2000, 'itemContainer height is correct after append');
+    assert.equal(paddingBefore(scrollContainer), 0, 'padding after is correct after append');
+    assert.equal(paddingAfter(scrollContainer), 1800, 'padding after is correct before prepend');
 
     await append(this, getNumbers(100, 20));
 
     assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '0 0', 'first item rendered correctly after append');
     assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '9 9', 'last item rendered correctly after append');
     assert.equal(scrollContainer.scrollTop, 0, 'scrollTop is correct after append');
-    assert.equal(containerHeight(itemContainer), 2400, 'itemContainer height is correct after append');
+    assert.equal(paddingBefore(scrollContainer), 0, 'b height is correct after append');
+    assert.equal(paddingAfter(scrollContainer), 2200, 'padding after is correct before prepend');
   }
 );
 
@@ -220,7 +222,7 @@ testScenarios(
   async function(assert) {
     assert.expect(4);
 
-    const itemContainer = find('vertical-collection');
+    const itemContainer = find('.scrollable');
 
     // Occlude a single item,
     await scrollTo('.scrollable', 0, 140);

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -393,19 +393,20 @@ testScenarios(
   hbs`
   <div style="height: 370px; width: 200px;" class="scrollable">
     <table class="table table-striped latest-data">
-      {{#vertical-collection items
-        containerSelector=".scrollable"
-        tagName="tbody"
-        estimateHeight=37
-        staticHeight=staticHeight
-        bufferSize=0
+      <tbody>
+        {{#vertical-collection items
+          containerSelector=".scrollable"
+          estimateHeight=37
+          staticHeight=staticHeight
+          bufferSize=0
 
-        as |item i|}}
-        <tr>
-          <td>{{item.number}}</td>
-          <td>{{i}}</td>
-        </tr>
-      {{/vertical-collection}}
+          as |item i|}}
+          <tr>
+            <td>{{item.number}}</td>
+            <td>{{i}}</td>
+          </tr>
+        {{/vertical-collection}}
+      </tbody>
     </table>
   </div>
   `,


### PR DESCRIPTION
This PR makes vertical-collection tagless by default. This is inline with the best-effort non-interventionist policy that Smoke and Mirrors has - by removing the base tag, the collection is effectively the same as an `{{each}}` in terms of structure, and has virtually no effect on the users styles.

Currently there are two common issues caused by the component having a tag:

1. Percent styles effectively can't be used for elements, as they would always be relative to the `vertical-collection` tag. This would limit the ability for users to make responsive layouts using the collection. Other styles could be affected by the presence of a the tag as well, but this is definitely the most problematic.

2. The element interferes in various layouts, such as in `table` elements where users would have to know to set the `tagName="tbody"` to make everything work.

I believe this will prevent future issues as well by preemptively reducing the impact we have on user's styles/structure.

An additional benefit of this refactor is it cleans up the flow for starting the Radar, and clearly defines ownership of the scrolling logic, which had been split between the component and Radar for quite some time. The way Radar now finds the scroll container is via the `occluded-content` elements which it adds to the DOM via `unbound`, effectively making it private state of the Radar. 

Note: Users can still use `tagName` and everything should work as expected, collections are tagless by default but having a tag shouldn't break anything.