### PR TITLE
bugfix(rem): Use the correct root element for rem based calculations

### DIFF
--- a/addon/-private/utils/element/estimate-element-height.js
+++ b/addon/-private/utils/element/estimate-element-height.js
@@ -25,7 +25,7 @@ function getPercentageHeight(element, fallbackHeight) {
 }
 
 function getEmHeight(element, fallbackHeight) {
-  const fontSizeElement = fallbackHeight.indexOf('rem') !== -1 ? document.body : element;
+  const fontSizeElement = fallbackHeight.indexOf('rem') !== -1 ? document.documentElement : element;
   const fontSize = window.getComputedStyle(fontSizeElement).getPropertyValue('font-size');
 
   return (parseFloat(fallbackHeight) * parseFloat(fontSize));

--- a/tests/integration/measurement-unit-test.js
+++ b/tests/integration/measurement-unit-test.js
@@ -61,7 +61,7 @@ testScenarios(
   `,
 
   async function(assert) {
-    assert.equal(findAll('vertical-item').length, 4);
+    assert.equal(findAll('vertical-item').length, 5);
   }
 );
 
@@ -115,7 +115,7 @@ testScenarios(
 
 testScenarios(
   'The collection renders correctly with a scroll parent with a pixel based max height',
-  simpleScenariosFor(getNumbers(0, 10)),
+  simpleScenariosFor(getNumbers(0, 20)),
 
   hbs`
     <div class="scrollable with-pixel-max-height">
@@ -142,7 +142,7 @@ testScenarios(
 
 testScenarios(
   'The collection renders correctly with a scroll parent with a percentage based max height',
-  simpleScenariosFor(getNumbers(0, 10)),
+  simpleScenariosFor(getNumbers(0, 20)),
 
   hbs`
     <div style="height: 400px;">
@@ -171,7 +171,7 @@ testScenarios(
 
 testScenarios(
   'The collection renders correctly with a scroll parent with an em based max height',
-  simpleScenariosFor(getNumbers(0, 10)),
+  simpleScenariosFor(getNumbers(0, 20)),
 
   hbs`
     <div style="font-size: 20px;">
@@ -200,7 +200,7 @@ testScenarios(
 
 testScenarios(
   'The collection renders correctly with a scroll parent with a rem based max height',
-  simpleScenariosFor(getNumbers(0, 10)),
+  simpleScenariosFor(getNumbers(0, 20)),
 
   hbs`
     <div class="scrollable with-rem-max-height">


### PR DESCRIPTION
The correct root element for rem based calculations is `document.documentElement`. Logically this makes sense, it allows us to set the root element to something like `10px` and then set the body to `14px` or another standard value. In testing rem based styles were being applied to items and getting multiplied by 10px, so I dived in and found this discrepancy.