### PR TITLE
feat(dynamic-pool): Implements a dynamic component pool with incremental render

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -43,13 +43,15 @@ export default class DynamicRadar extends Radar {
 
   afterUpdate() {
     // Schedule a check to see if we should rerender
-    this._nextIncrementalRender = this.schedule('sync', () => {
-      this._nextIncrementalRender = null;
+    if (this._nextIncrementalRender === null && this._nextUpdate === null) {
+      this._nextIncrementalRender = this.schedule('sync', () => {
+        this._nextIncrementalRender = null;
 
-      if (this._shouldScheduleRerender()) {
-        this.update();
-      }
-    });
+        if (this._shouldScheduleRerender()) {
+          this.update();
+        }
+      });
+    }
 
     super.afterUpdate();
   }

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -36,6 +36,7 @@ export default class DynamicRadar extends Radar {
     // Cancel incremental render check, since we'll be remeasuring anyways
     if (this._nextIncrementalRender !== null) {
       this._nextIncrementalRender.cancel();
+      this._nextIncrementalRender = null;
     }
 
     super.scheduleUpdate();

--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -43,7 +43,7 @@ export default class DynamicRadar extends Radar {
 
   afterUpdate() {
     // Schedule a check to see if we should rerender
-    this._nextIncrementalRender = this.schedule('measure', () => {
+    this._nextIncrementalRender = this.schedule('sync', () => {
       this._nextIncrementalRender = null;
 
       if (this._shouldScheduleRerender()) {

--- a/addon/-private/data-view/radar/static-radar.js
+++ b/addon/-private/data-view/radar/static-radar.js
@@ -16,10 +16,11 @@ export default class StaticRadar extends Radar {
 
   _updateIndexes() {
     const {
+      bufferSize,
       totalItems,
-      totalComponents,
       visibleMiddle,
-      _calculatedEstimateHeight
+      _calculatedEstimateHeight,
+      _calculatedScrollContainerHeight
     } = this;
 
     if (totalItems === 0) {
@@ -33,21 +34,30 @@ export default class StaticRadar extends Radar {
 
     const middleItemIndex = Math.floor(visibleMiddle / _calculatedEstimateHeight);
 
-    let firstItemIndex = middleItemIndex - Math.floor(totalComponents / 2);
-    let lastItemIndex = middleItemIndex + Math.ceil(totalComponents / 2) - 1;
+    const shouldRenderCount = Math.min(Math.ceil(_calculatedScrollContainerHeight / _calculatedEstimateHeight), totalItems);
+
+    let firstItemIndex = middleItemIndex - Math.floor(shouldRenderCount / 2);
+    let lastItemIndex = middleItemIndex + Math.ceil(shouldRenderCount / 2) - 1;
 
     if (firstItemIndex < 0) {
       firstItemIndex = 0;
-      lastItemIndex = Math.min(totalComponents - 1, maxIndex);
+      lastItemIndex = shouldRenderCount - 1;
     }
 
     if (lastItemIndex > maxIndex) {
       lastItemIndex = maxIndex;
-      firstItemIndex = Math.max(maxIndex - (totalComponents - 1), 0);
+      firstItemIndex = maxIndex - (shouldRenderCount - 1);
     }
+
+    firstItemIndex = Math.max(firstItemIndex - bufferSize, 0);
+    lastItemIndex = Math.min(lastItemIndex + bufferSize, maxIndex);
 
     this._firstItemIndex = firstItemIndex;
     this._lastItemIndex = lastItemIndex;
+  }
+
+  _didEarthquake(scrollDiff) {
+    return scrollDiff > (this._calculatedEstimateHeight / 2);
   }
 
   get total() {

--- a/addon/-private/data-view/skip-list.js
+++ b/addon/-private/data-view/skip-list.js
@@ -188,6 +188,7 @@ export default class SkipList {
 
   set(index, value) {
     assert('value must be a number', typeof value === 'number');
+    assert('value must non-negative', value >= 0);
     assert('index must be a number', typeof index === 'number');
     assert('index must be within bounds', index >= 0 && index < this.values.length);
 

--- a/addon/-private/data-view/utils/insert-range-before.js
+++ b/addon/-private/data-view/utils/insert-range-before.js
@@ -1,10 +1,9 @@
-export default function insertRangeBefore(element, firstNode, lastNode) {
-  const { parentNode } = element;
+export default function insertRangeBefore(parent, element, firstNode, lastNode) {
   let nextNode;
 
   while (firstNode) {
     nextNode = firstNode.nextSibling;
-    parentNode.insertBefore(firstNode, element);
+    parent.insertBefore(firstNode, element);
 
     if (firstNode === lastNode) {
       break;

--- a/addon/-private/data-view/virtual-component.js
+++ b/addon/-private/data-view/virtual-component.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
-import { IS_GLIMMER_2 } from 'ember-compatibility-helpers';
+import { IS_GLIMMER_2, GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
 
 const { set } = Ember;
 
@@ -25,7 +25,7 @@ export default class VirtualComponent {
     // adds observers which creates __ember_meta__
     this.__ember_meta__ = null; // eslint-disable-line camelcase
 
-    if (DEBUG) {
+    if (DEBUG && GTE_EMBER_1_13) {
       Object.preventExtensions(this);
     }
   }

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = {
         targets: [
           { dest: 'vertical-collection/-private.js', format: 'amd', moduleId: 'vertical-collection/-private' }
         ],
-        external: ['ember']
+        external: ['ember', 'ember-raf-scheduler']
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "broccoli-rollup": "^1.2.0",
     "ember-cli-babel": "^6.0.0-beta.10",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-compatibility-helpers": "^0.1.0",
+    "ember-compatibility-helpers": "^0.1.2",
     "ember-raf-scheduler": "0.1.0"
   },
   "engines": {

--- a/tests/acceptance/acceptance-tests/record-array-test.js
+++ b/tests/acceptance/acceptance-tests/record-array-test.js
@@ -12,8 +12,8 @@ if (VERSION.match(/1\.11\.\d+/) === null) {
   test('RecordArrays render correctly', async function(assert) {
     await visit('/acceptance-tests/record-array');
 
-    assert.equal(findAll('number-slide').length, 20, 'correct number of items rendered');
+    assert.equal(findAll('number-slide').length, 15, 'correct number of items rendered');
     assert.equal(find('number-slide:first-of-type').textContent.replace(/\s/g, ''), '0(0)', 'correct first item rendered');
-    assert.equal(find('number-slide:last-of-type').textContent.replace(/\s/g, ''), '19(19)', 'correct last item rendered');
+    assert.equal(find('number-slide:last-of-type').textContent.replace(/\s/g, ''), '14(14)', 'correct last item rendered');
   });
 }

--- a/tests/dummy/app/lib/get-numbers.js
+++ b/tests/dummy/app/lib/get-numbers.js
@@ -5,7 +5,7 @@ export default function(start, total, prefix = '') {
   let height;
 
   for (let i = start; i < start + total; i++) {
-    height = getDynamicHeight();
+    height = Math.max(getDynamicHeight() * Math.random(), 40);
     ret.push({
       number: i,
       height,

--- a/tests/dummy/app/routes/components/number-slide/component.js
+++ b/tests/dummy/app/routes/components/number-slide/component.js
@@ -41,7 +41,7 @@ export default Component.extend({
     let styleStr = `background: rgba(0,125,255,${opacity});`;
 
     if (isDynamic) {
-      styleStr += `height: ${Math.round(height / 2)}px; box-sizing: content-box; padding-bottom: ${Math.round(height / 10)}%;`;
+      styleStr += `height: ${Math.round(height)}px; box-sizing: content-box;`;
     }
 
     return htmlSafe(styleStr);

--- a/tests/dummy/app/routes/examples/flexible-layout/template.hbs
+++ b/tests/dummy/app/routes/examples/flexible-layout/template.hbs
@@ -8,6 +8,8 @@
             estimateHeight=270
             firstReached="loadAbove"
             lastReached="loadBelow"
+            bufferSize=0
+
             as |item index|
           }}
             {{number-slide isDynamic=true item=item index=index}}

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -124,7 +124,8 @@ function generateScenario(name, defaultOptions, initializer) {
     const items = initializer ? initializer(baseItems.slice()) : baseItems.slice();
     const scenario = { items };
 
-    Ember.merge(scenario, options, defaultOptions);
+    Ember.merge(scenario, options);
+    Ember.merge(scenario, defaultOptions);
 
     return { [name]: scenario };
   };

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -24,7 +24,7 @@ moduleForComponent('vertical-collection', 'Integration | Basic Tests', {
 });
 
 testScenarios(
-  'The collection Renders',
+  'The collection renders',
   scenariosFor(getNumbers(0, 1)),
   standardTemplate,
 
@@ -35,7 +35,7 @@ testScenarios(
 );
 
 testScenarios(
-  'The collection Renders when content is empty',
+  'The collection renders when content is empty',
   scenariosFor([]),
   standardTemplate,
 
@@ -64,16 +64,18 @@ testScenarios(
   async function(assert) {
     assert.expect(3);
 
-    // Should always render 3 components, one to span the space and two buffers
-    assert.equal(findAll('.vertical-item').length, 3);
+    // Should render buffer on the bottom
+    assert.equal(findAll('.vertical-item').length, 2);
 
     await scrollTo('.scrollable', 0, 200);
 
+    // Should render buffers on both sides
     assert.equal(findAll('.vertical-item').length, 3);
 
     await scrollTo('.scrollable', 0, 2000);
 
-    assert.equal(findAll('.vertical-item').length, 3);
+    // Should render buffer on the top
+    assert.equal(findAll('.vertical-item').length, 2);
   }
 );
 
@@ -309,7 +311,7 @@ testScenarios(
   async function(assert) {
     assert.expect(2);
 
-    assert.equal(findAll('vertical-item').length, 9, 'Rendered correct number of items');
+    assert.equal(findAll('vertical-item').length, 7, 'Rendered correct number of items');
 
     await scrollTo('.scrollable', 0, 500);
 

--- a/tests/integration/mutation-test.js
+++ b/tests/integration/mutation-test.js
@@ -225,7 +225,7 @@ testScenarios(
     const itemContainer = find('.scrollable');
 
     // Occlude a single item,
-    await scrollTo('.scrollable', 0, 140);
+    await scrollTo('.scrollable', 0, 41);
 
     assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '1 1', 'first item rendered correctly after initial scroll set');
     assert.equal(paddingBefore(itemContainer), 40, 'itemContainer padding correct before same items set');

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-import { find, scrollTo } from 'ember-native-dom-helpers';
+import { find, findAll, scrollTo } from 'ember-native-dom-helpers';
 
 import getNumbers from 'dummy/lib/get-numbers';
 import {
@@ -26,8 +26,6 @@ testScenarios(
   standardTemplate,
 
   function(assert) {
-    assert.expect(1);
-
     assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '49 49', 'the last item in the list should be rendered');
   }
 );
@@ -38,8 +36,6 @@ testScenarios(
   standardTemplate,
 
   function(assert) {
-    assert.expect(1);
-
     assert.equal(find('.scrollable').scrollTop, 500, 'the scroll container offset is correct');
   }
 );
@@ -50,8 +46,6 @@ testScenarios(
   standardTemplate,
 
   function(assert) {
-    assert.expect(1);
-
     assert.equal(find('.scrollable').scrollTop, 320, 'the scroll container offset is correct');
   }
 );
@@ -162,7 +156,7 @@ testScenarios(
 
 testScenarios(
   'Sends the lastReached action after append',
-  standardScenariosFor(getNumbers(0, 10), { lastReached: 'lastReached', bufferSize: 5 }),
+  standardScenariosFor(getNumbers(0, 5), { lastReached: 'lastReached', bufferSize: 5 }),
   standardTemplate,
 
   false, // Run test function before render
@@ -326,7 +320,7 @@ testScenarios(
 
 testScenarios(
   'Sends the lastReached action after append with renderAll set to true',
-  standardScenariosFor(getNumbers(0, 10), { lastReached: 'lastReached', bufferSize: 5, renderAll: true }),
+  standardScenariosFor(getNumbers(0, 5), { lastReached: 'lastReached', bufferSize: 5, renderAll: true }),
   standardTemplate,
 
   false, // Run test function before render
@@ -426,7 +420,7 @@ testScenarios(
 );
 
 testScenarios(
-  'Collection measures correctly when it\'s scroll parent has scrolled',
+  'Collection measures correctly when its scroll parent has scrolled',
   dynamicSimpleScenarioFor(getNumbers(0, 100)),
   hbs`
     <div style="height: 200px; width: 200px;" class="scroll-parent scrollable">
@@ -445,12 +439,13 @@ testScenarios(
   `,
 
   async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await scrollTo('.scroll-parent', 0, 200);
     await scrollTo('.scroll-child', 0, 400);
 
-    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '5 5', 'correct first item rendered');
+    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '10 10', 'correct first item rendered');
+    assert.equal(findAll('.vertical-item').length, 10, 'correct number of items rendered');
   }
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,9 +2580,9 @@ ember-code-snippet@^1.1.0:
     glob "^4.0.4"
     highlight.js "^9.5.0"
 
-ember-compatibility-helpers@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.0.tgz#52dbe15fd67cd357fdf3d2bdb1221467c87947c3"
+ember-compatibility-helpers@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.2.tgz#8eb1769ad761db273fd40242b1170d9f3841d0f0"
   dependencies:
     babel-plugin-debug-macros "^0.1.11"
     ember-cli-version-checker "^2.0.0"


### PR DESCRIPTION
This PR returns vertical-collection to a dynamic component pool, adding and removing components from the DOM as necessary based on actual component measurements. The goal is that we never render more items than we need to, allowing the collection to respond to varying sizes of items (e.g. items that are much larger or smaller than the estimate height).

The last time this strategy was attempted it was reverted due to being a performance regression. Destroying and re-creating components dynamically cost too much compared to the benefits. This time we're getting around that issue by never actually destroying any components. We simply remove their DOM, appending it to a temporary container element and then re-appending it when we need another component.

An additional feature required to make this fully work is incremental render. If enabled, the collection will measure and schedule render if it turned out it was wrong about the number of items needed,
for instance because they were too small.

TODO:
- [x] Add tests for incremental render
- [x] Better tests for:
  - [x] Prepend measurements (silent night)
  - [x] `renderFromLast`
  - [x] `didEarthquake`