### PR TITLE
bugfix(timing): Pulls prepend/append logic into Radar

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -32,14 +32,14 @@ export default class DynamicRadar extends Radar {
     this.skipList = null;
   }
 
-  scheduleUpdate() {
+  scheduleUpdate(didUpdateItems) {
     // Cancel incremental render check, since we'll be remeasuring anyways
     if (this._nextIncrementalRender !== null) {
       this._nextIncrementalRender.cancel();
       this._nextIncrementalRender = null;
     }
 
-    super.scheduleUpdate();
+    super.scheduleUpdate(didUpdateItems);
   }
 
   afterUpdate() {
@@ -274,9 +274,7 @@ export default class DynamicRadar extends Radar {
   reset() {
     super.reset();
 
-    if (this.skipList !== null) {
-      this.skipList.reset(this.totalItems);
-    }
+    this.skipList.reset(this.totalItems);
   }
 
   /*

--- a/addon/-private/data-view/utils/mutation-checkers.js
+++ b/addon/-private/data-view/utils/mutation-checkers.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+import objectAt from './object-at';
+import keyForItem from '../../ember-internals/key-for-item';
+
+const { get } = Ember;
+
+export function isPrepend(lenDiff, newItems, key, oldFirstKey, oldLastKey) {
+  const newItemsLength = get(newItems, 'length');
+
+  if (lenDiff <= 0 || lenDiff >= newItemsLength || newItemsLength === 0) {
+    return false;
+  }
+
+  const newFirstKey = keyForItem(objectAt(newItems, lenDiff), key, lenDiff);
+  const newLastKey = keyForItem(objectAt(newItems, newItemsLength - 1), key, newItemsLength - 1);
+
+  return oldFirstKey === newFirstKey && oldLastKey === newLastKey;
+}
+
+export function isAppend(lenDiff, newItems, key, oldFirstKey, oldLastKey) {
+  const newItemsLength = get(newItems, 'length');
+
+  if (lenDiff <= 0 || lenDiff >= newItemsLength || newItemsLength === 0) {
+    return false;
+  }
+
+  const newFirstKey = keyForItem(objectAt(newItems, 0), key, 0);
+  const newLastKey = keyForItem(objectAt(newItems, newItemsLength - lenDiff - 1), key, newItemsLength - lenDiff - 1);
+
+  return oldFirstKey === newFirstKey && oldLastKey === newLastKey;
+}

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -151,48 +151,16 @@ const VerticalCollection = Component.extend({
   shouldYieldToInverse: computed.readOnly('isEmpty'),
 
   virtualComponents: computed('items.[]', 'renderAll', 'estimateHeight', 'bufferSize', function() {
-    const {
-      _radar,
-      _prevItemsLength,
-      _prevFirstKey,
-      _prevLastKey
-    } = this;
+    const { _radar } = this;
 
+    const items = this.get('items');
+
+    _radar.items = items === null || items === undefined ? [] : items;
     _radar.estimateHeight = this.get('estimateHeight');
     _radar.renderAll = this.get('renderAll');
     _radar.bufferSize = this.get('bufferSize');
 
-    const items = this.get('items');
-    const itemsLength = get(items, 'length');
-
-    if (items === null || items === undefined || itemsLength === 0) {
-      _radar.items = [];
-      _radar.reset();
-      _radar.scheduleUpdate();
-
-      this._prevItemsLength = this._prevFirstKey = this._prevLastKey = 0;
-
-      return _radar.virtualComponents;
-    }
-
-    _radar.items = items;
-
-    const key = this.get('key');
-    const lenDiff = itemsLength - _prevItemsLength;
-
-    this._prevItemsLength = itemsLength;
-    this._prevFirstKey = keyForItem(objectAt(items, 0), key, 0);
-    this._prevLastKey = keyForItem(objectAt(items, itemsLength - 1), key, itemsLength - 1);
-
-    if (isPrepend(lenDiff, items, key, _prevFirstKey, _prevLastKey) === true) {
-      _radar.prepend(lenDiff);
-    } else if (isAppend(lenDiff, items, key, _prevFirstKey, _prevLastKey) === true) {
-      _radar.append(lenDiff);
-    } else {
-      _radar.reset();
-    }
-
-    _radar.scheduleUpdate();
+    _radar.scheduleUpdate(true);
 
     return _radar.virtualComponents;
   }),
@@ -266,6 +234,7 @@ const VerticalCollection = Component.extend({
         estimateHeight,
         initialRenderCount,
         items,
+        key,
         renderAll,
         renderFromLast,
         shouldRecycle,
@@ -332,32 +301,6 @@ function calculateStartingIndex(items, idForFirstItem, key, renderFromLast) {
   }
 
   return startingIndex;
-}
-
-function isPrepend(lenDiff, newItems, key, oldFirstKey, oldLastKey) {
-  const newItemsLength = get(newItems, 'length');
-
-  if (lenDiff <= 0 || lenDiff >= newItemsLength || newItemsLength === 0) {
-    return false;
-  }
-
-  const newFirstKey = keyForItem(objectAt(newItems, lenDiff), key, lenDiff);
-  const newLastKey = keyForItem(objectAt(newItems, newItemsLength - 1), key, newItemsLength - 1);
-
-  return oldFirstKey === newFirstKey && oldLastKey === newLastKey;
-}
-
-function isAppend(lenDiff, newItems, key, oldFirstKey, oldLastKey) {
-  const newItemsLength = get(newItems, 'length');
-
-  if (lenDiff <= 0 || lenDiff >= newItemsLength || newItemsLength === 0) {
-    return false;
-  }
-
-  const newFirstKey = keyForItem(objectAt(newItems, 0), key, 0);
-  const newLastKey = keyForItem(objectAt(newItems, newItemsLength - lenDiff - 1), key, newItemsLength - lenDiff - 1);
-
-  return oldFirstKey === newFirstKey && oldLastKey === newLastKey;
 }
 
 export default VerticalCollection;

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import { moduleForComponent } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
@@ -460,5 +461,26 @@ testScenarios(
     await scrollTo('.scrollable', 0, 10000);
 
     assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '49 49', 'the last item in the list should be rendered');
+  }
+);
+
+testScenarios(
+  'The collection does not allow interaction before being setup',
+  standardScenariosFor(getNumbers(100, 100)),
+  standardTemplate,
+
+  false, // Run test function before render
+  async function(assert) {
+    assert.expect(2);
+
+    run(() => {
+      prepend(this, getNumbers(10, 10));
+      prepend(this, getNumbers(0, 10));
+    });
+
+    await wait();
+
+    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '0 0', 'Rendered correct number of items');
+    assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '9 9', 'Rendered correct number of items');
   }
 );


### PR DESCRIPTION
Pulls the prepend/append/reset logic into Radar due to issues with
timing guarantees. This guaratees that we will check the state of the
array when we are going to update, not when we are scheduling the
change. In certain edge cases, updates to the array can occur between
when the computed property is calculated and the Radar actually updates.