### PR TITLE
Move ember-cli-version-checker to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-cli-version-checker": "^1.2.0",
     "ember-code-snippet": "^1.1.0",
     "ember-data": "^2.12.2",
     "ember-disable-prototype-extensions": "^1.1.0",
@@ -65,6 +64,7 @@
     "broccoli-rollup": "^1.2.0",
     "ember-cli-babel": "^6.0.0-beta.10",
     "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-version-checker": "^1.2.0",
     "ember-compatibility-helpers": "^0.1.2",
     "ember-raf-scheduler": "0.1.0"
   },


### PR DESCRIPTION
This should fix the issue of `checker.assertAbove is not a function`.