### PR TITLE
refactor(container): Rename Container to ViewportContainer

### DIFF
--- a/addon/-debug/edge-visualization/debug-mixin.js
+++ b/addon/-debug/edge-visualization/debug-mixin.js
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import Mixin from '@ember/object/mixin';
 import Visualization from './visualization';
-import Container from '../../-private';
+import { ViewportContainer } from '../../-private';
 
 import {
   styleIsOneOf,
@@ -33,7 +33,7 @@ export default Mixin.create({
     let styles;
 
     // check telescope
-    if (radar.scrollContainer !== Container) {
+    if (radar.scrollContainer !== ViewportContainer) {
       styles = window.getComputedStyle(radar.scrollContainer);
     } else {
       styles = window.getComputedStyle(document.body);
@@ -44,7 +44,7 @@ export default Mixin.create({
     assert(`scrollContainer must define height or max-height`, hasStyleWithNonZeroValue(styles, 'height') || hasStyleWithNonZeroValue(styles, 'max-height'));
 
     // conditional perf check for non-body scrolling
-    if (radar.scrollContainer !== Container) {
+    if (radar.scrollContainer !== ViewportContainer) {
       assert(`scrollContainer must define overflow-y`, hasStyleValue(styles, 'overflow-y', 'scroll') || hasStyleValue(styles, 'overflow', 'scroll'));
     }
 

--- a/addon/-debug/edge-visualization/visualization.js
+++ b/addon/-debug/edge-visualization/visualization.js
@@ -1,5 +1,5 @@
 /* global document */
-import { Container } from '../../-private';
+import { ViewportContainer } from '../../-private';
 
 function applyVerticalStyles(element, geography) {
   element.style.height = `${geography.height}px`;
@@ -44,7 +44,7 @@ export default class Visualization {
     this.container.style.height = `${_scrollContainer.getBoundingClientRect().height}px`;
 
     applyVerticalStyles(this.scrollContainer, _scrollContainer.getBoundingClientRect());
-    applyVerticalStyles(this.screen, Container.getBoundingClientRect());
+    applyVerticalStyles(this.screen, ViewportContainer.getBoundingClientRect());
   }
 
   makeSatellite() {

--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -16,7 +16,7 @@ import {
   removeScrollHandler
 } from '../utils/scroll-handler';
 
-import Container from '../container';
+import ViewportContainer from '../viewport-container';
 
 import closestElement from '../../utils/element/closest';
 import estimateElementHeight from '../../utils/element/estimate-element-height';
@@ -142,7 +142,7 @@ export default class Radar {
 
     if (this._started) {
       removeScrollHandler(this._scrollContainer, this._scrollHandler);
-      Container.removeEventListener('resize', this._resizeHandler);
+      ViewportContainer.removeEventListener('resize', this._resizeHandler);
     }
   }
 
@@ -164,7 +164,7 @@ export default class Radar {
     // Use the occluded content element, which has been inserted into the DOM,
     // to find the item container and the scroll container
     this._itemContainer = _occludedContentBefore.element.parentNode;
-    this._scrollContainer = containerSelector === 'body' ? Container : closestElement(this._itemContainer, containerSelector);
+    this._scrollContainer = containerSelector === 'body' ? ViewportContainer : closestElement(this._itemContainer, containerSelector);
 
     this._updateConstants();
 
@@ -195,7 +195,7 @@ export default class Radar {
 
     // Setup event handlers
     addScrollHandler(this._scrollContainer, this._scrollHandler);
-    Container.addEventListener('resize', this._resizeHandler);
+    ViewportContainer.addEventListener('resize', this._resizeHandler);
   }
 
   /*

--- a/addon/-private/data-view/viewport-container.js
+++ b/addon/-private/data-view/viewport-container.js
@@ -12,7 +12,7 @@
  * to access and set the scrollTop and scrollLeft properties.
  *
  */
-export function Container() {
+export function ViewportContainer() {
 
   // A bug occurs in Chrome when we reload the browser at a lower
   // scrollTop, window.scrollY becomes stuck on a single value.
@@ -48,15 +48,15 @@ export function Container() {
   });
 }
 
-Container.prototype.addEventListener = function addEventListener(event, handler, options) {
+ViewportContainer.prototype.addEventListener = function addEventListener(event, handler, options) {
   return window.addEventListener(event, handler, options);
 };
 
-Container.prototype.removeEventListener = function addEventListener(event, handler, options) {
+ViewportContainer.prototype.removeEventListener = function addEventListener(event, handler, options) {
   return window.removeEventListener(event, handler, options);
 };
 
-Container.prototype.getBoundingClientRect = function getBoundingClientRect() {
+ViewportContainer.prototype.getBoundingClientRect = function getBoundingClientRect() {
   return {
     height: window.innerHeight,
     width: window.innerWidth,
@@ -67,4 +67,4 @@ Container.prototype.getBoundingClientRect = function getBoundingClientRect() {
   };
 };
 
-export default new Container();
+export default new ViewportContainer();

--- a/addon/-private/index.js
+++ b/addon/-private/index.js
@@ -5,7 +5,7 @@ export { default as closestElement } from './utils/element/closest';
 export { default as DynamicRadar } from './data-view/radar/dynamic-radar';
 export { default as StaticRadar } from './data-view/radar/static-radar';
 
-export { default as Container } from './data-view/container';
+export { default as ViewportContainer } from './data-view/viewport-container';
 export { default as objectAt } from './data-view/utils/object-at';
 
 export {


### PR DESCRIPTION
Rename to clarify the purpose of this class. In memory debugging and
elsewhere the name can clash with other more general classes, such as
Ember's DI container.

Fixes #163