### PR TITLE
Fix treeForAddon super call

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = {
     });
 
     // use the default options
-    const addonTemplateTree = this._super(templateTree);
+    const addonTemplateTree = this._super.treeForAddon.call(this, templateTree);
     let publicTree = babel.transpileTree(withoutPrivate);
 
     privateTree = new Rollup(privateTree, {


### PR DESCRIPTION
`this._super` is not called correctly and can lead to error like this:
```
ctjhoa@gits ..rc/main/webapp/static/jscripts/app-cli (git)-[CPM-1050] % ember serve
WARNING: WARNING: Node v6.10.3 has currently not been tested against Ember CLI and may result in unexpected behaviour.
Could not start watchman; falling back to NodeWatcher for file system events.
Visit http://ember-cli.com/user-guide/#watchman for more info.
this._super is not a function
TypeError: this._super is not a function
at Class.treeForAddon (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-light-table/node_modules/@html-next/vertical-collection/index.js:64:36)
at Class._treeFor (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:322:31)
at Class.treeFor (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:290:19)
at /home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:244:32
at Array.map (native)
at Class.eachAddonInvoke (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:242:22)
at Class.treeFor (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:289:20)
at /home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/broccoli/ember-app.js:463:20
at Array.map (native)
at EmberApp.addonTreesFor (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/broccoli/ember-app.js:461:30)
```