### PR TITLE
Remove "find host" loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,15 +125,6 @@ module.exports = {
     this._super.included.apply(this, arguments);
     this.checker = new VersionChecker(app);
 
-    while (typeof app.import !== 'function' && app.app) {
-      app = app.app;
-    }
-
-    if (typeof app.import !== 'function') {
-      throw new Error('vertical-collection is being used within another addon or engine '
-        + 'and is having trouble registering itself to the parent application.');
-    }
-
     this._env = app.env;
     this._setupBabelOptions(app.env);
 


### PR DESCRIPTION
"find host" loop breaks import functionality with latest versions of Ember CLI. [It is a part of `app.import`](https://github.com/ember-cli/ember-cli/blob/v3.0.0-beta.2/lib/models/addon.js#L675) now and no longer needed here.