### PR TITLE
Bugfix - Fix issue where IE crashed trying to set source of a null reference

### DIFF
--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -22,6 +22,7 @@ import closestElement from '../../utils/element/closest';
 import estimateElementHeight from '../../utils/element/estimate-element-height';
 import getScaledClientRect from '../../utils/element/get-scaled-client-rect';
 import keyForItem from '../../ember-internals/key-for-item';
+import { IS_EMBER_2 } from 'ember-compatibility-helpers';
 
 export default class Radar {
   constructor(
@@ -123,7 +124,9 @@ export default class Radar {
 
     // In older versions of Ember/IE, binding anything on an object in the template
     // adds observers which creates __ember_meta__
-    this.__ember_meta__ = null; // eslint-disable-line camelcase
+    if (!IS_EMBER_2) {
+      this.__ember_meta__ = undefined; // eslint-disable-line camelcase
+    }
 
     if (DEBUG) {
       this._debugDidUpdate = null;


### PR DESCRIPTION
Fixes #74
Caused Error: "TypeError: Unable to get property 'source' of undefined or null reference" (in meta.js)

As discussed in the issue, changing the code to only set `this.__ember_meta__` when in an older version of ember is found. Also changed it to `undefined` instead of `null` so the comparison in Ember meta.js file will catch it when it is unset.