### PR TITLE
API to specify custom occluded content tag

### DIFF
--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -37,7 +37,8 @@ export default class Radar {
       renderAll,
       renderFromLast,
       shouldRecycle,
-      startingIndex
+      startingIndex,
+      occlusionTagName
     }
   ) {
     this.token = new Token(parentToken);
@@ -107,8 +108,10 @@ export default class Radar {
     this._occludedContentBefore = new VirtualComponent();
     this._occludedContentAfter = new VirtualComponent();
 
-    this._occludedContentBefore.element = document.createElement('occluded-content');
-    this._occludedContentAfter.element = document.createElement('occluded-content');
+    this._occludedContentBefore.element = document.createElement(occlusionTagName);
+    this._occludedContentBefore.element.className += 'occluded-content';
+    this._occludedContentAfter.element = document.createElement(occlusionTagName);
+    this._occludedContentAfter.element.className += 'occluded-content';
 
     this._occludedContentBefore.element.addEventListener('click', this.pageUp.bind(this));
     this._occludedContentAfter.element.addEventListener('click', this.pageDown.bind(this));

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -144,6 +144,14 @@ const VerticalCollection = Component.extend({
    */
   renderAll: false,
 
+  /**
+   * The tag name used in DOM elements before and after the rendered list. By default, it is set to
+   * 'occluded-content' to avoid any confusion with user's CSS settings. However, it could be
+   * overriden to provide custom behavior (for example, in table user wants to set it to 'tr' to
+   * comply with table semantics).
+   */
+  occlusionTagName: 'occluded-content',
+
   isEmpty: empty('items'),
   shouldYieldToInverse: readOnly('isEmpty'),
 
@@ -217,6 +225,7 @@ const VerticalCollection = Component.extend({
     const renderAll = this.get('renderAll');
     const renderFromLast = this.get('renderFromLast');
     const shouldRecycle = this.get('shouldRecycle');
+    const occlusionTagName = this.get('occlusionTagName');
 
     const idForFirstItem = this.get('idForFirstItem');
     const key = this.get('key');
@@ -235,7 +244,8 @@ const VerticalCollection = Component.extend({
         renderAll,
         renderFromLast,
         shouldRecycle,
-        startingIndex
+        startingIndex,
+        occlusionTagName
       }
     );
 

--- a/addon/styles/app.css
+++ b/addon/styles/app.css
@@ -1,4 +1,4 @@
-occluded-content {
+.occluded-content {
   display: block;
   position: relative;
   width: 100%;
@@ -10,16 +10,17 @@ occluded-content {
   color: rgba(0,0,0,0);
 }
 
-table > occluded-content,
-tbody > occluded-content,
-thead > occluded-content {
+table .occluded-content,
+tbody .occluded-content,
+thead .occluded-content,
+tfoot .occluded-content, {
   display: table-row;
   position: relative;
   width: 100%;
 }
 
-ul > occluded-content,
-ol > occluded-content {
+ul .occluded-content,
+ol .occluded-content {
   display: list-item;
   position: relative;
   width: 100%;

--- a/tests/integration/a11y-test.js
+++ b/tests/integration/a11y-test.js
@@ -50,8 +50,8 @@ testScenarios(
   standardTemplate,
 
   async function(assert) {
-    const occludedBefore = find('occluded-content:first-of-type');
-    const occludedAfter = find('occluded-content:last-of-type');
+    const occludedBefore = find('.occluded-content:first-of-type');
+    const occludedAfter = find('.occluded-content:last-of-type');
 
     assert.equal(occludedBefore.textContent.trim(), '', 'occluded before text correct when no items before');
     assert.equal(occludedAfter.textContent.trim(), 'And 10 items after', 'occluded after text correct when some items after');
@@ -79,8 +79,8 @@ testScenarios(
   standardTemplate,
 
   async function(assert) {
-    const occludedBefore = find('occluded-content:first-of-type');
-    const occludedAfter = find('occluded-content:last-of-type');
+    const occludedBefore = find('.occluded-content:first-of-type');
+    const occludedAfter = find('.occluded-content:last-of-type');
 
     assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '0 0', 'correct first item rendered');
     assert.equal(find('.vertical-item:last-of-type').textContent.trim(), '9 9', 'correct last item rendered');

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -132,7 +132,7 @@ testScenarios(
   async function(assert) {
     assert.expect(3);
 
-    let occludedBoundaries = findAll('occluded-content');
+    let occludedBoundaries = findAll('.occluded-content');
 
     assert.equal(occludedBoundaries[0].getAttribute('style'), 'height: 0px;', 'Occluded height above is correct');
     assert.equal(occludedBoundaries[1].getAttribute('style'), 'height: 100px;', 'Occluded height below is correct');
@@ -164,7 +164,7 @@ testScenarios(
   async function(assert) {
     assert.expect(3);
 
-    let occludedBoundaries = findAll('occluded-content');
+    let occludedBoundaries = findAll('.occluded-content');
 
     assert.equal(occludedBoundaries[0].getAttribute('style'), 'height: 0px;', 'Occluded height above is correct');
     assert.equal(occludedBoundaries[1].getAttribute('style'), 'height: 100px;', 'Occluded height below is correct');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,6 +1392,13 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
+broccoli-merge-trees@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.0.tgz#90e4959f9e3c57cf1f04fab35152f3d849468d8b"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^2.0.0"
+
 broccoli-middleware@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.0.0.tgz#92f4e1fb9a791ea986245a7077f35cc648dab097"
@@ -1742,6 +1749,10 @@ clean-css@^3.4.5:
   dependencies:
     commander "2.8.x"
     source-map "0.4.x"
+
+clean-up-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-up-path/-/clean-up-path-1.0.0.tgz#de9e8196519912e749c9eaf67c13d64fac72a3e5"
 
 cli-cursor@^1.0.1:
   version "1.0.2"
@@ -2577,9 +2588,9 @@ ember-compatibility-helpers@^0.1.2:
     ember-cli-version-checker "^2.0.0"
     semver "^5.4.1"
 
-ember-data@^2.12.2:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.18.0.tgz#8e374e540ea7c3b101983eb51cd0beedaa4d230d"
+ember-data@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.0.2.tgz#bfedc6cfd3cdfcf89de7e18f272085a9b33ea930"
   dependencies:
     amd-name-resolver "0.0.7"
     babel-plugin-ember-modules-api-polyfill "^1.4.2"
@@ -2648,9 +2659,9 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-native-dom-helpers@^0.5.2:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.10.tgz#9c7172e4ddfa5dd86830c46a936e2f8eca3e5896"
+ember-native-dom-helpers@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.2.tgz#ad1f82d64ac9abdd612022f4f390bdb6653b3d39"
   dependencies:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
@@ -2902,14 +2913,14 @@ eslint-plugin-ember@^5.0.0:
     require-folder-tree "^1.4.5"
     snake-case "^2.1.0"
 
-eslint-plugin-node@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz#80df3253c4d7901045ec87fa660a284e32bdca29"
+eslint-plugin-node@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz#bf19642298064379315d7a4b2a75937376fa05e4"
   dependencies:
     ignore "^3.3.6"
     minimatch "^3.0.4"
     resolve "^1.3.3"
-    semver "5.3.0"
+    semver "^5.4.1"
 
 eslint-scope@^3.7.1:
   version "3.7.1"
@@ -3494,6 +3505,16 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
 
+fs-updater@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fs-updater/-/fs-updater-1.0.4.tgz#2329980f99ae9176e9a0e84f7637538a182ce63b"
+  dependencies:
+    can-symlink "^1.0.0"
+    clean-up-path "^1.0.0"
+    heimdalljs "^0.2.5"
+    heimdalljs-logger "^0.1.9"
+    rimraf "^2.6.2"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -3858,7 +3879,7 @@ heimdalljs-logger@^0.1.7, heimdalljs-logger@^0.1.9:
     debug "^2.2.0"
     heimdalljs "^0.2.0"
 
-heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
+heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"
   dependencies:
@@ -5020,6 +5041,13 @@ merge-trees@^1.0.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
+merge-trees@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-2.0.0.tgz#a560d796e566c5d9b2c40472a2967cca48d85161"
+  dependencies:
+    fs-updater "^1.0.4"
+    heimdalljs "^0.2.5"
+
 merge@^1.1.3, merge@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -6107,7 +6135,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -6210,10 +6238,6 @@ sane@^2.2.0:
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.1.1, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-
-semver@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
 semver@^4.3.1:
   version "4.3.6"


### PR DESCRIPTION
Allow user to specify custom occluded tag through `occlusionTagName` field. This allows component like table to comply with table semantics. 

