### PR TITLE
upgrade compatibility-helpers to 1.0.0

### DIFF
--- a/addon/-private/data-view/elements/occluded-content.js
+++ b/addon/-private/data-view/elements/occluded-content.js
@@ -1,7 +1,7 @@
 import { set } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
 
-import { IS_GLIMMER_2, GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
+import { IS_GLIMMER_2, gte as emberVersionGTE } from 'ember-compatibility-helpers';
 import document from '../../utils/document-shim';
 
 let OC_IDENTITY = 0;
@@ -31,7 +31,7 @@ export default class OccludedContent {
     // adds observers which creates __ember_meta__
     this.__ember_meta__ = null; // eslint-disable-line camelcase
 
-    if (DEBUG && GTE_EMBER_1_13) {
+    if (DEBUG && emberVersionGTE('1.13.0')) {
       Object.preventExtensions(this);
     }
   }

--- a/addon/-private/data-view/elements/virtual-component.js
+++ b/addon/-private/data-view/elements/virtual-component.js
@@ -2,7 +2,7 @@ import { set } from '@ember/object';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
-import { IS_GLIMMER_2, GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
+import { IS_GLIMMER_2, gte as emberVersionGTE } from 'ember-compatibility-helpers';
 import document from '../../utils/document-shim';
 
 let VC_IDENTITY = 0;
@@ -26,7 +26,7 @@ export default class VirtualComponent {
     // adds observers which creates __ember_meta__
     this.__ember_meta__ = null; // eslint-disable-line camelcase
 
-    if (DEBUG && GTE_EMBER_1_13) {
+    if (DEBUG && emberVersionGTE('1.13.0')) {
       Object.preventExtensions(this);
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.3",
     "ember-cli-version-checker": "^2.1.0",
-    "ember-compatibility-helpers": "^0.1.2",
+    "ember-compatibility-helpers": "^1.0.0",
     "ember-raf-scheduler": "0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
bring `ember-compatibility-helpers` up to date to avoid `dependency-lint` errors