### PR TITLE
[CHORE] Fix the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "bootstrap": "~3.3.5",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-assign-polyfill": "^2.6.0",
     "ember-cli": "~3.1.4",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-changelog": "0.3.4",

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -4,6 +4,6 @@
     bufferSize=5
 
     as |item index|}}
-    {{number-slide item=item index=index}}
+    {{number-slide item=item itemIndex=index}}
   {{/vertical-collection}}
 </div>

--- a/tests/dummy/app/routes/components/number-slide/component.js
+++ b/tests/dummy/app/routes/components/number-slide/component.js
@@ -41,7 +41,7 @@ export default Component.extend({
     return htmlSafe(styleStr);
   }),
   layout,
-  index: 0,
+  itemIndex: 0,
   item: null,
   number: alias('item.number')
 });

--- a/tests/dummy/app/routes/components/number-slide/template.hbs
+++ b/tests/dummy/app/routes/components/number-slide/template.hbs
@@ -1,2 +1,2 @@
 <div class="number">{{if prefixed number item.prefixed}}</div>
-<div class="index">({{index}})</div>
+<div class="index">({{itemIndex}})</div>

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -1,7 +1,7 @@
 import { A } from '@ember/array';
 import ArrayProxy from '@ember/array/proxy';
 import { Promise } from 'rsvp';
-import { merge } from '@ember/polyfills';
+import Ember from 'ember';
 import { test } from 'ember-qunit';
 import DS from 'ember-data';
 import hbs from 'htmlbars-inline-precompile';
@@ -118,8 +118,8 @@ function generateScenario(name, defaultOptions, initializer) {
     const items = initializer ? initializer(baseItems.slice()) : baseItems.slice();
     const scenario = { items };
 
-    merge(scenario, options);
-    merge(scenario, defaultOptions);
+    Ember.assign(scenario, options); // eslint-disable-line ember/new-module-imports
+    Ember.assign(scenario, defaultOptions); // eslint-disable-line ember/new-module-imports
 
     return { [name]: scenario };
   };
@@ -128,7 +128,7 @@ function generateScenario(name, defaultOptions, initializer) {
 function mergeScenarioGenerators(...scenarioGenerators) {
   return function(items, options) {
     return scenarioGenerators.reduce((scenarios, generator) => {
-      return merge(scenarios, generator(items, options));
+      return Ember.assign(scenarios, generator(items, options)); // eslint-disable-line ember/new-module-imports
     }, {});
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,7 +710,7 @@ amd-name-resolver@0.0.7:
   dependencies:
     ensure-posix-path "^1.0.1"
 
-amd-name-resolver@^1.2.0:
+amd-name-resolver@1.2.0, amd-name-resolver@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz#fc41b3848824b557313897d71f8d5a0184fbe679"
   dependencies:
@@ -1535,7 +1535,7 @@ babel-plugin-undefined-to-void@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz#7f578ef8b78dfae6003385d8417a61eda06e2f81"
 
-babel-polyfill@^6.16.0:
+babel-polyfill@^6.16.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -1543,7 +1543,7 @@ babel-polyfill@^6.16.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-env@^1.5.1:
+babel-preset-env@^1.5.1, babel-preset-env@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
   dependencies:
@@ -1864,6 +1864,22 @@ broccoli-babel-transpiler@^5.6.2:
 broccoli-babel-transpiler@^6.0.0, broccoli-babel-transpiler@^6.1.2:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.4.2.tgz#f9e453ce664d5735baecabbc50e62c1b93b1796d"
+  dependencies:
+    babel-core "^6.26.0"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-persistent-filter "^1.4.3"
+    clone "^2.0.0"
+    hash-for-dep "^1.2.3"
+    heimdalljs-logger "^0.1.7"
+    json-stable-stringify "^1.0.0"
+    rsvp "^4.8.2"
+    workerpool "^2.3.0"
+
+broccoli-babel-transpiler@^6.5.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz#a4afc8d3b59b441518eb9a07bd44149476e30738"
+  integrity sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==
   dependencies:
     babel-core "^6.26.0"
     broccoli-funnel "^2.0.1"
@@ -3109,6 +3125,14 @@ electron-to-chromium@^1.3.86:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.90.tgz#b4c51b8303beff18f2b74817402bf4898e09558a"
   integrity sha512-IjJZKRhFbWSOX1w0sdIXgp4CMRguu6UYcTckyFF/Gjtemsu/25eZ+RXwFlV+UWcIueHyQA1UnRJxocTpH5NdGA==
 
+ember-assign-polyfill@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.6.0.tgz#07847e3357ee35b33f886a0b5fbec6873f6860eb"
+  integrity sha512-Y8NzOmHI/g4PuJ+xC14eTYiQbigNYddyHB8FY2kuQMxThTEIDE7SJtgttJrYYcPciOu0Tnb5ff36iO46LeiXkw==
+  dependencies:
+    ember-cli-babel "^6.16.0"
+    ember-cli-version-checker "^2.0.0"
+
 ember-cli-app-version@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-app-version/-/ember-cli-app-version-3.2.0.tgz#7b9ad0e1b63ae0518648356ee24c703e922bc26e"
@@ -3143,6 +3167,25 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.5:
     clone "^2.0.0"
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
+
+ember-cli-babel@^6.16.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
+  integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
 
 ember-cli-babel@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
- Use assign from ember-assign-polyfill instead of Ember.merge
This will remove many deprecation warnings raised in the test environment. It seems like it makes Travis fail to read the result of the tests otherwise.

![Screen Shot 2019-04-23 at 8 51 44 AM](https://user-images.githubusercontent.com/743977/56604636-4c989780-65b7-11e9-901d-a75954f84df9.png)


- Rename index to itemIndex in `number-slide`
I haven't tracked down the problem but it seems like Ember thinks that
`{{index}}` inside the `number-slide` component is not the property but the template
for the `index` route.
I doubt this is a bug with `vertical-collection`.