### PR TITLE
Remove comma in selector list in css

### DIFF
--- a/addon/styles/app.css
+++ b/addon/styles/app.css
@@ -13,7 +13,7 @@
 table .occluded-content,
 tbody .occluded-content,
 thead .occluded-content,
-tfoot .occluded-content, {
+tfoot .occluded-content {
   display: table-row;
   position: relative;
   width: 100%;


### PR DESCRIPTION
This was creating an issue with an autoprefixer in an engine where it added a prefix to the empty string after the comma, giving an element whose name matched the prefix the table .occluded-content properties