### PR TITLE
Restore support for Ember 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
       matrix:
         ember-version:
           [
-            # ember-lts-2.8,
-            # ember-lts-2.12,
-            # ember-lts-2.18,
+            ember-lts-2.8,
+            ember-lts-2.12,
+            ember-lts-2.18,
             ember-lts-3.4,
             ember-lts-3.8,
             ember-lts-3.12,

--- a/addon/-private/data-view/elements/occluded-content.js
+++ b/addon/-private/data-view/elements/occluded-content.js
@@ -1,5 +1,6 @@
 import { set } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
+import { IS_GLIMMER_2, gte as emberVersionGTE } from 'ember-compatibility-helpers';
 
 import document from '../../utils/document-shim';
 
@@ -26,6 +27,12 @@ export default class OccludedContent {
     this.isOccludedContent = true;
     this.rendered = false;
 
+    if (!emberVersionGTE('3.0.0')) {
+      // In older versions of Ember, binding anything on an object in the template
+      // adds observers which creates __ember_meta__
+      this.__ember_meta__ = null; // eslint-disable-line camelcase
+    }
+
     if (DEBUG) {
       Object.preventExtensions(this);
     }
@@ -50,11 +57,11 @@ export default class OccludedContent {
   }
 
   get realUpperBound() {
-    return this.upperBound;
+    return IS_GLIMMER_2 ? this.upperBound : this.upperBound.previousSibling;
   }
 
   get realLowerBound() {
-    return this.lowerBound;
+    return IS_GLIMMER_2 ? this.lowerBound : this.lowerBound.nextSibling;
   }
 
   get parentNode() {

--- a/addon/-private/data-view/elements/virtual-component.js
+++ b/addon/-private/data-view/elements/virtual-component.js
@@ -1,6 +1,7 @@
 import { set } from '@ember/object';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
+import { IS_GLIMMER_2, gte as emberVersionGTE } from 'ember-compatibility-helpers';
 
 import document from '../../utils/document-shim';
 
@@ -21,17 +22,23 @@ export default class VirtualComponent {
 
     this.rendered = false;
 
+    if (!emberVersionGTE('3.0.0')) {
+      // In older versions of Ember, binding anything on an object in the template
+      // adds observers which creates __ember_meta__
+      this.__ember_meta__ = null; // eslint-disable-line camelcase
+    }
+
     if (DEBUG) {
       Object.preventExtensions(this);
     }
   }
 
   get realUpperBound() {
-    return this.upperBound;
+    return IS_GLIMMER_2 ? this.upperBound : this.upperBound.previousSibling;
   }
 
   get realLowerBound() {
-    return this.lowerBound;
+    return IS_GLIMMER_2 ? this.lowerBound : this.lowerBound.nextSibling;
   }
 
   getBoundingClientRect() {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -18,8 +18,15 @@ module.exports = async function() {
         },
         npm: {
           devDependencies: {
-            'ember-source': null
+            'ember-source': null,
+            'ember-factory-for-polyfill': '1.3.1'
           },
+          dependencies: {
+            'ember-compatibility-helpers': '1.2.1'
+          },
+          resolutions: {
+            'ember-compatibility-helpers': '1.2.1'
+          }
         },
       },
       {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -33,6 +33,7 @@ module.exports = async function() {
         name: 'ember-lts-2.12',
         npm: {
           devDependencies: {
+            '@ember/jquery': '^1.1.0',
             'ember-source': '~2.12.0'
           },
         },
@@ -41,6 +42,7 @@ module.exports = async function() {
         name: 'ember-lts-2.18',
         npm: {
           devDependencies: {
+            '@ember/jquery': '^1.1.0',
             'ember-source': '~2.18.0'
           },
         },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "broccoli-funnel": "^2.0.2",
     "broccoli-merge-trees": "^3.0.1",
     "broccoli-rollup": "^4.1.1",
+    "ember-compatibility-helpers": "^1.2.1",
     "ember-cli-babel": "^7.12.0",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-version-checker": "^3.1.3",
@@ -98,8 +99,5 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  },
-  "resolutions": {
-    "ember-compatibility-helpers": "1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "ember-raf-scheduler": "0.2.0"
   },
   "devDependencies": {
-    "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^0.7.0",
     "bootstrap": "~3.3.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,3 +1,3 @@
 {
-  "jquery-integration": true
+  "jquery-integration": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4042,6 +4042,15 @@ ember-cli-version-checker@^4.1.0:
     semver "^6.3.0"
     silent-error "^1.1.1"
 
+ember-cli-version-checker@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz#649c7b6404902e3b3d69c396e054cea964911ab0"
+  integrity sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==
+  dependencies:
+    resolve-package-path "^3.1.0"
+    semver "^7.3.4"
+    silent-error "^1.1.1"
+
 ember-cli@~3.12.0:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.12.1.tgz#b387c206d4091f91685ba7323ececbbcfb80282a"
@@ -4152,13 +4161,22 @@ ember-code-snippet@^2.4.1:
     es6-promise "^1.0.0"
     glob "^7.1.3"
 
-ember-compatibility-helpers@1.2.1, ember-compatibility-helpers@^1.1.1:
+ember-compatibility-helpers@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.1.tgz#87c92c4303f990ff455c28ca39fb3ee11441aa16"
   integrity sha512-6wzYvnhg1ihQUT5yGqnLtleq3Nv5KNv79WhrEuNU9SwR4uIxCO+KpyC7r3d5VI0EM7/Nmv9Nd0yTkzmTMdVG1A==
   dependencies:
     babel-plugin-debug-macros "^0.2.0"
     ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
+
+ember-compatibility-helpers@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.2.tgz#839e0c24190b7a2ec8c39b80e030811b1a95b6d3"
+  integrity sha512-EKyCGOGBvKkBsk6wKfg3GhjTvTTkcEwzl/cv4VYvZM18cihmjGNpliR4BymWsKRWrv4VJLyq15Vhk3NHkSNBag==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
     semver "^5.4.1"
 
 ember-data@3.11.5:
@@ -6704,6 +6722,13 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -8050,6 +8075,14 @@ resolve-package-path@^2.0.0:
     path-root "^0.1.1"
     resolve "^1.13.1"
 
+resolve-package-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-3.1.0.tgz#35faaa5d54a9c7dd481eb7c4b2a44410c9c763d8"
+  integrity sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==
+  dependencies:
+    path-root "^0.1.1"
+    resolve "^1.17.0"
+
 resolve-path@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
@@ -8063,7 +8096,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
@@ -8233,6 +8266,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"
@@ -9513,6 +9553,11 @@ yallist@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yam@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,18 +948,6 @@
     ember-cli-typescript "^2.0.1"
     heimdalljs "^0.3.0"
 
-"@ember/jquery@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ember/jquery/-/jquery-1.1.0.tgz#33d062610a5ceaa5c5c8a3187f870d47d6595940"
-  integrity sha512-zePT3LiK4/2bS4xafrbOlwoLJrDFseOZ95OOuVDyswv8RjFL+9lar+uxX6+jxRb0w900BcQSWP/4nuFSK6HXXw==
-  dependencies:
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.2"
-    ember-cli-babel "^7.11.1"
-    ember-cli-version-checker "^3.1.3"
-    jquery "^3.4.1"
-    resolve "^1.11.1"
-
 "@ember/optional-features@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.7.0.tgz#f65a858007020ddfb8342f586112750c32abd2d9"
@@ -3755,7 +3743,7 @@ ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
+ember-cli-babel@^7.1.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
   version "7.23.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.23.1.tgz#d1517228ede08a5d4b045c78a7429728e956b30b"
   integrity sha512-qYggmt3hRs6QJ6cRkww3ahMpyP8IEV2KFrIRO/Z6hu9MkE/8Y28Xd5NjQl6fPV3oLoG0vwuHzhNe3Jr7Wec8zw==


### PR DESCRIPTION
`master` of the vertical-collection repo had some Ember-pre-3.x
compatibility stuff removed back in 2019. For example:

* https://github.com/html-next/vertical-collection/commit/011d9a48272e80cf8e76df9be383244615597a09

Restore one of those changes.