### PR TITLE
Remove property fallback lookup (no implicit this)

### DIFF
--- a/addon/components/vertical-collection/template.hbs
+++ b/addon/components/vertical-collection/template.hbs
@@ -1,4 +1,4 @@
-{{#each virtualComponents key="id" as |virtualComponent| ~}}
+{{#each this.virtualComponents key="id" as |virtualComponent| ~}}
   {{~unbound virtualComponent.upperBound~}}
   {{~#if virtualComponent.isOccludedContent ~}}
     {{{unbound virtualComponent.element}}}
@@ -8,6 +8,6 @@
   {{~unbound virtualComponent.lowerBound~}}
 {{~/each}}
 
-{{#if shouldYieldToInverse}}
+{{#if this.shouldYieldToInverse}}
   {{yield to="inverse"}}
 {{/if}}

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -1,8 +1,7 @@
 <div class="table-wrapper dark">
-  {{#vertical-collection model
+  {{#vertical-collection this.model
     estimateHeight=50
     bufferSize=5
-
     as |item index|}}
     {{number-slide item=item itemIndex=index}}
   {{/vertical-collection}}

--- a/tests/dummy/app/routes/components/number-slide/template.hbs
+++ b/tests/dummy/app/routes/components/number-slide/template.hbs
@@ -1,2 +1,2 @@
-<div class="number">{{if prefixed number item.prefixed}}</div>
-<div class="index">({{itemIndex}})</div>
+<div class="number">{{if this.prefixed this.number this.item.prefixed}}</div>
+<div class="index">({{this.itemIndex}})</div>

--- a/tests/dummy/app/routes/examples/dbmon/components/dbmon-row/template.hbs
+++ b/tests/dummy/app/routes/examples/dbmon/components/dbmon-row/template.hbs
@@ -1,12 +1,12 @@
 <td class="dbname">
-  {{attrs.db.id}}
+  {{this.db.id}}
 </td>
 <td class="query-count">
-  <span class="{{countClassName}}">
-    {{queries.length}}
+  <span class="{{this.countClassName}}">
+    {{this.queries.length}}
   </span>
 </td>
-{{#each topFiveQueries key="@index" as |query|}}
+{{#each this.topFiveQueries key="@index" as |query|}}
   <td>{{query.elapsed}}</td>
   <div class="popover bottom">
     <div class="popover-content">{{query.query}}</div>

--- a/tests/dummy/app/routes/examples/flexible-layout/template.hbs
+++ b/tests/dummy/app/routes/examples/flexible-layout/template.hbs
@@ -5,7 +5,7 @@
       {{!- BEGIN-SNIPPET flexible-layout-example }}
       <div class="table-wrapper dark">
         {{#vertical-collection
-          model.numbers
+          this.model.numbers
           estimateHeight=270
           firstReached=(action "loadAbove")
           lastReached=(action "loadBelow")

--- a/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
@@ -5,7 +5,7 @@
       {{!- BEGIN-SNIPPET infinite-scroll-example }}
       <div class="table-wrapper dark">
         {{#vertical-collection
-          model.numbers
+          this.model.numbers
           estimateHeight=90
           staticHeight=true
           bufferSize=5

--- a/tests/dummy/app/routes/examples/reduce-debug/template.hbs
+++ b/tests/dummy/app/routes/examples/reduce-debug/template.hbs
@@ -4,7 +4,7 @@
       <h3>Demo</h3>
       <div class="table-wrapper dark">
         {{#vertical-collection
-          items=model.filtered
+          items=this.model.filtered
           defaultHeight=270
           useContentProxy=false
         as |item index|

--- a/tests/dummy/app/routes/examples/scrollable-body/template.hbs
+++ b/tests/dummy/app/routes/examples/scrollable-body/template.hbs
@@ -3,7 +3,7 @@
     <div class="col-sm-7">
       {{!- BEGIN-SNIPPET scrollable-body-example }}
       {{#vertical-collection
-        model.numbers
+        this.model.numbers
         estimateHeight=40
         containerSelector="body" as |item index|
       }}


### PR DESCRIPTION
Backport of https://github.com/html-next/vertical-collection/pull/334

See: https://deprecations.emberjs.com/v3.x#toc_this-property-fallback