### PR TITLE
Drop Ember global use in favor of native API

### DIFF
--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -1,7 +1,6 @@
 import { A } from '@ember/array';
 import ArrayProxy from '@ember/array/proxy';
 import { Promise } from 'rsvp';
-import Ember from 'ember';
 import { test } from 'ember-qunit';
 import DS from 'ember-data';
 import hbs from 'htmlbars-inline-precompile';
@@ -123,8 +122,8 @@ function generateScenario(name, defaultOptions, initializer) {
     const items = initializer ? initializer(baseItems.slice()) : baseItems.slice();
     const scenario = { items };
 
-    Ember.assign(scenario, options); // eslint-disable-line ember/new-module-imports
-    Ember.assign(scenario, defaultOptions); // eslint-disable-line ember/new-module-imports
+    Object.assign(scenario, options);
+    Object.assign(scenario, defaultOptions);
 
     return { [name]: scenario };
   };
@@ -133,7 +132,7 @@ function generateScenario(name, defaultOptions, initializer) {
 function mergeScenarioGenerators(...scenarioGenerators) {
   return function(items, options) {
     return scenarioGenerators.reduce((scenarios, generator) => {
-      return Ember.assign(scenarios, generator(items, options)); // eslint-disable-line ember/new-module-imports
+      return Object.assign(scenarios, generator(items, options));
     }, {});
   };
 }


### PR DESCRIPTION
IE11 support ended in https://github.com/html-next/vertical-collection/pull/321. I think we're good to use Object.assign (https://caniuse.com/mdn-javascript_builtins_object_assign)