### PR TITLE
Extend timeout for base tests, tweak retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 6
+    timeout-minutes: 12
 
     steps:
       - name: Checkout
@@ -31,14 +31,14 @@ jobs:
         run: yarn lint
 
       - name: Run Tests
-        run: yarn test:ember
+        run: bin/run-tests-with-retry.sh
         env:
           CI: true
 
   test-ember-try:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 14
 
     strategy:
       fail-fast: false

--- a/bin/run-tests-with-retry.sh
+++ b/bin/run-tests-with-retry.sh
@@ -4,7 +4,7 @@ function retry {
     command="$*"
     retval=1
     attempt=1
-    until [[ $retval -eq 0 ]] || [[ $attempt -gt 5 ]]; do
+    until [[ $retval -eq 0 ]] || [[ $attempt -gt 3 ]]; do
         # Execute inside of a subshell in case parent
         # script is running with "set -e"
         (
@@ -18,10 +18,10 @@ function retry {
             sleep 10
         fi
     done
-    if [[ $retval -ne 0 ]] && [[ $attempt -gt 2 ]]; then
+    if [[ $retval -ne 0 ]] && [[ $attempt -gt 3 ]]; then
         # Something is fubar, go ahead and exit
         exit $retval
     fi
 }
 
-retry ember test
+retry yarn test:ember


### PR DESCRIPTION
The retry script was incorrectly adjusting the max attempts, correct it and set the attempt count at 3.