### PR TITLE
Delete virtual element

### DIFF
--- a/tests/acceptance/acceptance-tests/record-array-test.js
+++ b/tests/acceptance/acceptance-tests/record-array-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 
-import { find, findAll, visit as newVisit } from '@ember/test-helpers';
+import { click, find, findAll, visit as newVisit } from '@ember/test-helpers';
 
 module('Acceptance | Record Array', function(hooks) {
   setupApplicationTest(hooks);
@@ -12,5 +12,17 @@ module('Acceptance | Record Array', function(hooks) {
     assert.equal(findAll('number-slide').length, 15, 'correct number of items rendered');
     assert.equal(find('number-slide:first-of-type').textContent.replace(/\s/g, ''), '0(0)', 'correct first item rendered');
     assert.equal(find('number-slide:last-of-type').textContent.replace(/\s/g, ''), '14(14)', 'correct last item rendered');
+  });
+
+  test('RecordArrays updates correctly after deleting items', async function(assert) {
+    await newVisit('/acceptance-tests/record-array');
+
+    assert.equal(findAll('number-slide').length, 15, 'correct number of items rendered');
+    await click('#update-items-button');
+    assert.equal(findAll('number-slide').length, 5, 'correct number of items rendered');
+    assert.deepEqual(findAll('number-slide').map(s => s.textContent.trim()[0]), ['0', '1', '2', '3', '4'], 'correct items order');
+    await click('#show-prefixed-button');
+    assert.equal(findAll('number-slide').length, 5, 'correct number of items rendered and nothing crashes');
+    assert.deepEqual(findAll('number-slide').map(s => s.textContent.trim()[0]), ['0', '1', '2', '3', '4'], 'correct items order');
   });
 });

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -18,5 +18,10 @@ for (let i = 0; i < 100; i++) {
 export default DS.JSONAPIAdapter.extend({
   findAll() {
     return RSVP.Promise.resolve(NUMBERS);
-  }
+  },
+  query(store, model, query) {
+    const queryData = { ...NUMBERS };
+    queryData.data = NUMBERS.data.slice(0, query.length);
+    return RSVP.Promise.resolve(queryData);
+  },
 });

--- a/tests/dummy/app/models/number-item.js
+++ b/tests/dummy/app/models/number-item.js
@@ -8,7 +8,7 @@ const {
 
 export default Model.extend({
   number: attr('number'),
-  prefixed: computed(function() {
+  prefixed: computed('number', function() {
     return `${this.get('number')}`;
   })
 });

--- a/tests/dummy/app/routes/acceptance-tests/record-array/controller.js
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/controller.js
@@ -1,0 +1,18 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+  store: service(),
+  prefixed: true,
+
+  actions: {
+    updateItems() {
+      this.get('store').unloadAll('number-item');
+      this.get('store').query('number-item', { length: 5 });
+    },
+
+    showPrefixed() {
+      this.toggleProperty('prefixed');
+    }
+  }
+});

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -3,6 +3,9 @@
     estimateHeight=50
     bufferSize=5
     as |item index|}}
-    {{number-slide item=item itemIndex=index}}
+    {{number-slide item=item itemIndex=index prefixed=this.prefixed}}
   {{/vertical-collection}}
 </div>
+
+<button id="update-items-button" {{action "updateItems"}}>Update items</button>
+<button id="show-prefixed-button" {{action "showPrefixed"}}>Show prefixed</button>


### PR DESCRIPTION
Issue - https://github.com/html-next/vertical-collection/issues/357
See [test updating deleted elements](https://github.com/html-next/vertical-collection/pull/358/commits/39571e5d519c963d161819dd92d19a3bf964a273) commit to reproduce the issue in tests

**Description**:
The radar has a domPool virtual element to save temporarily deleted nodes and reuse them when a new item is added. So if the item is deleted from the items list the item's node can still exist in the virtual dom so the item's component can be still updated by Ember.

This behavior isn't working for computed fields on the ember models. Ember rejects the error when trying to access the computed property on the destroyed object if it hasn't been consumed before. This is possible if the items' component should render more fields after the update.

To avoid re-rendering deleted items it's better to delete related components from the virtual pool. It doesn't give much impact on performance as this can happen only if the component has fewer total items than virtual items after the update and it also doesn't affect scroll rendering.

