### PR TITLE
Don't send action on non-existing items

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -184,6 +184,10 @@ const VerticalCollection = Component.extend({
 
           this._scheduledActions.forEach(([action, index]) => {
             const item = objectAt(items, index);
+            if (!item) {
+              return;
+            }
+
             const key = keyForItem(item, keyPath, index);
 
             // this.sendAction will be deprecated in ember 4.0


### PR DESCRIPTION
This is a straightforward fix for https://github.com/html-next/vertical-collection/issues/317.
We tried a more sophisticated fix https://github.com/html-next/vertical-collection/pull/324, but the error didn't vanish - it rather started to appear more seldom. So eventually we decided to perform this check on the `item` which utterly fixes the issue.
- Check that the item the event is being generated for still exists.