### PR TITLE
Lower the timeout for test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 8
 
     steps:
       - name: Checkout
@@ -38,7 +38,7 @@ jobs:
   test-ember-try:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 14
+    timeout-minutes: 9
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Tests seem to rarely finish if they go over 8ish minutes. Lower the timeout.