### PR TITLE
Add explicit exit to retry

### DIFF
--- a/bin/run-tests-with-retry.sh
+++ b/bin/run-tests-with-retry.sh
@@ -18,10 +18,7 @@ function retry {
             sleep 1
         fi
     done
-    if [[ $retval -ne 0 ]] && [[ $attempt -gt 4 ]]; then
-        # Something is fubar, go ahead and exit
-        exit $retval
-    fi
+    exit $retval
 }
 
 yarn run ember build && retry yarn run ember test --path=dist


### PR DESCRIPTION
The retry script was previously not explicit about exiting with the status of the passed command execution. Make it so.

Should be harmless at worst.