### PR TITLE
fix: enable parallel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   test-ember-try:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 9
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,7 +7,11 @@ module.exports = function(defaults) {
   defaults.snippetSearchPaths = ['tests/dummy/app'];
   defaults.snippetPaths = ['tests/dummy/snippets'];
 
-  let app = new EmberAddon(defaults);
+  let app = new EmberAddon(defaults, {
+    'ember-cli-babel': {
+      throwUnlessParallelizable: true
+    }
+  });
 
   app.isDevelopingAddon = () => {
     return true;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const StripClassCallCheckPlugin = require('babel6-plugin-strip-class-callcheck');
+const StripClassCallCheckPlugin = require.resolve('babel6-plugin-strip-class-callcheck');
 const Funnel = require('broccoli-funnel');
 const Rollup = require('broccoli-rollup');
 const merge = require('broccoli-merge-trees');

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ module.exports = {
     const opts = {
       loose: true,
       plugins,
-      postTransformPlugins: [StripClassCallCheckPlugin]
+      postTransformPlugins: [[StripClassCallCheckPlugin, {}]]
     };
 
     return opts;


### PR DESCRIPTION
tests will also catch regressions now that the flag is set to be on for our own builds. This is a non-breaking change and can be released as a patch.