### PR TITLE
Lower a CI timeout back to 9 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   test-ember-try:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 9
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
There is something in the vertical collection test suite which periodically hangs the action runner. Extending the timeout to 15 minutes doesn't make it more likely we get a green build, instead it increases the delay you need to wait before retrying.

Relates to #382