### PR TITLE
Adopt angle bracket invocation, update readme, drop positional param

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,24 @@ ember install @html-next/vertical-collection
 ## Usage
 
 ```htmlbars
-{{#vertical-collection
-    items
-    tagName='ul'
-    estimateHeight=50
-    staticHeight=false
-    bufferSize=1
-    renderAll=false
-    renderFromLast=false
-    idForFirstItem=idForFirstItem
-    firstReached=(action firstReached)
-    lastReached=(action lastReached)
-    firstVisibleChanged=(action firstVisibleChanged)
-    lastVisibleChanged=(action lastVisibleChanged)
-     as |item i|}}
+<VerticalCollection
+    @items={{items}}
+    @tagName="ul"
+    @estimateHeight={{50}}
+    @staticHeight={{false}}
+    @bufferSize={{1}}
+    @renderAll={{false}}
+    @renderFromLast={{false}}
+    @idForFirstItem={{idForFirstItem}}
+    @firstReached={{firstReachedCallback}}
+    @lastReached={{lastReachedCallback}}
+    @firstVisibleChanged={{firstVisibleChangedCallback}}
+    @lastVisibleChanged={{lastVisibleChangedCallback}}
+     as |item i|>
     <li>
       {{item.number}} {{i}}
     </li>
-{{/vertical-collection}}
+</VerticalCollection>
 ```
 
 ### Actions
@@ -67,6 +67,7 @@ ember install @html-next/vertical-collection
 | `^v1.x.x`                     | `v1.12.0 - v3.8.x`       | `?`                     |
 | `^v2.x.x`                     | `v2.8.0 - v3.26.x`       | `v12 - ?`               |
 | `^v3.x.x`                     | `v2.18.0+`               | `v14+`                  |
+| `^v4.x.x`                     | `v3.12.0+`               | `v14+`                  |
 
 ## Support, Questions, Collaboration
 

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -43,7 +43,7 @@ const VerticalCollection = Component.extend({
 
   /**
    * List of objects to svelte-render.
-   * Can be called like `{{#vertical-collection <items-array>}}`, since it's the first positional parameter of this component.
+   * Can be called like `<VerticalCollection @items={{itemsArray}} />`.
    *
    * @property items
    * @type Array
@@ -310,11 +310,11 @@ const VerticalCollection = Component.extend({
 
       Template:
 
-      {{vertical-collection registerAPI=(action "registerAPI")}}
+      <VerticalCollection @registerAPI={{action "registerAPI"}} />
 
       Component:
       
-       export default Component.extend({
+      export default Component.extend({
         actions: {
           registerAPI(api) {
               this.set('collectionAPI', api);
@@ -341,10 +341,6 @@ const VerticalCollection = Component.extend({
       registerAPI(publicAPI);
     }
   }
-});
-
-VerticalCollection.reopenClass({
-  positionalParams: ['items']
 });
 
 function calculateStartingIndex(items, idForFirstItem, key, renderFromLast) {

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -1,10 +1,10 @@
 <div class="table-wrapper dark">
-  {{#vertical-collection this.model
-    estimateHeight=50
-    bufferSize=5
-    as |item index|}}
-    {{number-slide item=item itemIndex=index prefixed=this.prefixed}}
-  {{/vertical-collection}}
+  <VerticalCollection @items={{this.model}}
+    @estimateHeight={{50}}
+    @bufferSize={{5}}
+    as |item index|>
+    <NumberSlide @item={{item}} @itemIndex={{index}} @prefixed={{this.prefixed}} />
+  </VerticalCollection>
 </div>
 
 <button id="update-items-button" {{action "updateItems"}}>Update items</button>

--- a/tests/dummy/app/routes/examples/dbmon/template.hbs
+++ b/tests/dummy/app/routes/examples/dbmon/template.hbs
@@ -7,17 +7,17 @@
         <div class="table-wrapper">
           <table class="table table-striped latest-data">
             <tbody>
-              {{#vertical-collection
-                model.databases
-                containerSelector=".table-wrapper"
-                key="id"
+              <VerticalCollection
+                @items={{model.databases}}
+                @containerSelector=".table-wrapper"
+                @key="id"
 
-                estimateHeight=37
-                staticHeight=true
-                bufferSize=5 as |db|
-              }}
-                {{examples/dbmon/components/dbmon-row tagName="tr" db=db}}
-              {{/vertical-collection}}
+                @estimateHeight={{37}}
+                @staticHeight={{true}}
+                @bufferSize={{5}}
+              as |db|>
+                <Examples::Dbmon::Components::DbmonRow @tagName="tr" @db={{db}} />
+              </VerticalCollection>
             </tbody>
           </table>
         </div>
@@ -34,7 +34,7 @@
         focusing only on what's on screen now.
       </p>
       <h4>Code for Demo</h4>
-      {{code-snippet name="dbmon-example.hbs"}}
+      <CodeSnippet @name="dbmon-example.hbs" />
     </div>
   </div>
 </div>

--- a/tests/dummy/app/routes/examples/flexible-layout/template.hbs
+++ b/tests/dummy/app/routes/examples/flexible-layout/template.hbs
@@ -4,15 +4,14 @@
       <h3>Demo</h3>
       {{!- BEGIN-SNIPPET flexible-layout-example }}
       <div class="table-wrapper dark">
-        {{#vertical-collection
-          this.model.numbers
-          estimateHeight=270
-          firstReached=(action "loadAbove")
-          lastReached=(action "loadBelow")
-          bufferSize=0 as |item index|
-        }}
-          {{number-slide isDynamic=true item=item index=index}}
-        {{/vertical-collection}}
+        <VerticalCollection @items={{this.model.numbers}}
+          @estimateHeight={{270}}
+          @firstReached={{action "loadAbove"}}
+          @lastReached={{action "loadBelow"}}
+          @bufferSize={{0}} as |item index|
+          >
+          <NumberSlide @isDynamic={{true}} @item={{item}} @index={{index}} />
+        </VerticalCollection>
       </div>
       {{!- END-SNIPPET }}
     </div>
@@ -27,7 +26,7 @@
         with integration with the pre-render component.
       </p>
       <h4>Code for Demo</h4>
-      {{code-snippet name="flexible-layout-example.hbs"}}
+      <CodeSnippet @name="flexible-layout-example.hbs" />
     </div>
   </div>
 </div>

--- a/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
+++ b/tests/dummy/app/routes/examples/infinite-scroll/template.hbs
@@ -4,16 +4,16 @@
       <h3>Demo</h3>
       {{!- BEGIN-SNIPPET infinite-scroll-example }}
       <div class="table-wrapper dark">
-        {{#vertical-collection
-          this.model.numbers
-          estimateHeight=90
-          staticHeight=true
-          bufferSize=5
-          firstReached=(action "loadAbove")
-          lastReached=(action "loadBelow") as |item index|
-        }}
-          {{number-slide item=item index=index}}
-        {{/vertical-collection}}
+        <VerticalCollection
+          @items={{this.model.numbers}}
+          @estimateHeight={{90}}
+          @staticHeight={{true}}
+          @bufferSize={{5}}
+          @firstReached={{action "loadAbove"}}
+          @lastReached={{action "loadBelow"}} as |item index|
+        >
+          <NumberSlide @item={{item}} @index={{index}} />
+        </VerticalCollection>
       </div>
       {{!- END-SNIPPET }}
     </div>

--- a/tests/dummy/app/routes/examples/reduce-debug/template.hbs
+++ b/tests/dummy/app/routes/examples/reduce-debug/template.hbs
@@ -3,16 +3,15 @@
     <div class="col-sm-5">
       <h3>Demo</h3>
       <div class="table-wrapper dark">
-        {{#vertical-collection
-          items=this.model.filtered
-          defaultHeight=270
-          useContentProxy=false
-        as |item index|
-        }}
+        <VerticalCollection
+          @items={{this.model.filtered}}
+          @defaultHeight={{270}}
+          @useContentProxy={{false}}
+        as |item index|>
           <div class="image-slide">
-            {{examples/infinite-scroll/components/number-slide number=item.number index=index}}
+            <Examples::InfiniteScroll::Components::NumberSlide @number={{item.number}} @index={{index}} />
           </div>
-        {{/vertical-collection}}
+        </VerticalCollection>
       </div>
     </div>
     <div class="col-sm-7">

--- a/tests/dummy/app/routes/examples/scrollable-body/template.hbs
+++ b/tests/dummy/app/routes/examples/scrollable-body/template.hbs
@@ -2,19 +2,19 @@
   <div class="row">
     <div class="col-sm-7">
       {{!- BEGIN-SNIPPET scrollable-body-example }}
-      {{#vertical-collection
-        this.model.numbers
-        estimateHeight=40
-        containerSelector="body" as |item index|
-      }}
-        {{number-slide isDynamic=true item=item index=index}}
-      {{/vertical-collection}}
+      <VerticalCollection
+        @items={{this.model.numbers}}
+        @estimateHeight={{40}}
+        @containerSelector="body" as |item index|
+      >
+      <NumberSlide @isDynamic={{true}} @item={{item}} @index={{index}} />
+      </VerticalCollection>
       {{!- END-SNIPPET }}
     </div>
     <div class="col-sm-5">
       <h3>Scrolling based on the whole page.</h3>
       <h4>Code for Demo</h4>
-      {{code-snippet name="scrollable-body-example.hbs"}}
+      <CodeSnippet @name="scrollable-body-example.hbs" />
     </div>
   </div>
 </div>

--- a/tests/dummy/app/routes/settings/snippets/defaults.js
+++ b/tests/dummy/app/routes/settings/snippets/defaults.js
@@ -8,7 +8,7 @@ export default
 
   // Positional parameter, e.g.
   //
-  // `{{#vertical-collection items as |item|}}`
+  // `<VerticalCollection @items={{items}} as |item|>`
   //
   // Note: An alias for this property named `content`
   // exists solely for Ember 1.11 support. The alias

--- a/tests/dummy/app/routes/settings/template.hbs
+++ b/tests/dummy/app/routes/settings/template.hbs
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-sm-7">
       <h4>Available Settings (with defaults)</h4>
-      {{code-snippet name="vertical-collection-defaults-example.js"}}
+      <CodeSnippet @name="vertical-collection-defaults-example.js" />
     </div>
     <div class="col-sm-5">
       <h3>Vertical Collection</h3>

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -78,32 +78,32 @@ export const scenariosFor = mergeScenarioGenerators(
 
 export const standardTemplate = hbs`
   <div style="height: 200px; width: 100px;" class="scrollable">
-    {{#vertical-collection this.items
-      estimateHeight=(either-or this.estimateHeight 20)
-      staticHeight=this.staticHeight
-      bufferSize=(either-or this.bufferSize 0)
-      renderAll=this.renderAll
-      debugVis=(either-or this.debugVis false)
-      debugCSS=(either-or this.debugCSS false)
+    <VerticalCollection @items={{this.items}}
+      @estimateHeight={{either-or this.estimateHeight 20}}
+      @staticHeight={{this.staticHeight}}
+      @bufferSize={{either-or this.bufferSize 0}}
+      @renderAll={{this.renderAll}}
+      @debugVis={{either-or this.debugVis false}}
+      @debugCSS={{either-or this.debugCSS false}}
 
-      renderFromLast=this.renderFromLast
-      idForFirstItem=this.idForFirstItem
+      @renderFromLast={{this.renderFromLast}}
+      @idForFirstItem={{this.idForFirstItem}}
 
-      firstVisibleChanged=this.firstVisibleChanged
-      lastVisibleChanged=this.lastVisibleChanged
-      firstReached=this.firstReached
-      lastReached=this.lastReached
+      @firstVisibleChanged={{this.firstVisibleChanged}}
+      @lastVisibleChanged={{this.lastVisibleChanged}}
+      @firstReached={{this.firstReached}}
+      @lastReached={{this.lastReached}}
 
-      key=(either-or this.key "@identity")
+      @key={{either-or this.key "@identity"}}
 
-      as |item i|}}
+      as |item i|>
       <div
         class="vertical-item"
         style={{html-safe (join-strings "height:" (either-or this.itemHeight (either-or this.estimateHeight 20)) "px;")}}
       >
         {{item.number}} {{i}}
       </div>
-    {{/vertical-collection}}
+    </VerticalCollection>
   </div>
 `;
 

--- a/tests/integration/basic-test.js
+++ b/tests/integration/basic-test.js
@@ -97,17 +97,17 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
     hbs`
       <div style="height: 100px;" class="scrollable">
         <div>
-          {{#vertical-collection this.items
-            containerSelector=".scrollable"
-            estimateHeight=20
-            staticHeight=true
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @containerSelector=".scrollable"
+            @estimateHeight={{20}}
+            @staticHeight={{true}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <vertical-item style="height: 20px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,
@@ -125,17 +125,17 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
     hbs`
       <div style="height: 100px; padding-top: 50px;" class="scrollable">
         <div>
-          {{#vertical-collection this.items
-            containerSelector=".scrollable"
-            estimateHeight=20
-            staticHeight=true
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @containerSelector=".scrollable"
+            @estimateHeight={{20}}
+            @staticHeight={{true}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <vertical-item style="height: 20px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,
@@ -158,16 +158,16 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
     hbs`
       <div style="position: relative; background: red; box-sizing: content-box; height: 100px; overflow-y: scroll;" class="scrollable">
         <div style="padding: 200px;">
-          {{#vertical-collection this.items
-            containerSelector=".scrollable"
-            estimateHeight=20
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @containerSelector=".scrollable"
+            @estimateHeight={{20}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <vertical-item style="height: 28px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,
@@ -189,11 +189,11 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
 
     hbs`
       <div style="height: 500px; width: 500px;">
-        {{#vertical-collection this.items
-          estimateHeight=10
-          containerSelector="body"
+        <VerticalCollection @items={{this.items}}
+          @estimateHeight={{10}}
+          @containerSelector="body"
           as |item|
-        }}
+        >
           <div>
             Content
             {{#if item.shouldRender}}
@@ -202,7 +202,7 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
               </section>
             {{/if}}
           </div>
-        {{/vertical-collection}}
+        </VerticalCollection>
       </div>
     `,
 
@@ -218,15 +218,15 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
     assertAfterInitialRender(() => {
       render(hbs`
         <div style="height: 500px; width: 500px;" class="scrollable">
-          {{#vertical-collection this.items
-            estimateHeight=50
-            initialRenderCount=1
+          <VerticalCollection @items={{this.items}}
+            @estimateHeight={{50}}
+            @initialRenderCount={{1}}
             as |item i|
-          }}
+          >
             <vertical-item style="height: 50px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       `);
     }, () => {
@@ -248,17 +248,17 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
     assertAfterInitialRender(() => {
       render(hbs`
         <div style="height: 500px; width: 500px;" class="scrollable">
-          {{#vertical-collection this.items
-            estimateHeight=50
-            initialRenderCount=1
-            idForFirstItem="20"
-            key="number"
+          <VerticalCollection @items={{this.items}}
+            @estimateHeight={{50}}
+            @initialRenderCount={{1}}
+            @idForFirstItem="20"
+            @key="number"
             as |item i|
-          }}
+          >
             <vertical-item style="height: 50px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       `);
     }, () => {
@@ -280,15 +280,15 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
     assertAfterInitialRender(() => {
       render(hbs`
         <div style="height: 500px; width: 500px;" class="scrollable">
-          {{#vertical-collection this.items
-            estimateHeight=50
-            initialRenderCount=5
+          <VerticalCollection @items={{this.items}}
+            @estimateHeight={{50}}
+            @initialRenderCount={{5}}
             as |item i|
-          }}
+          >
             <vertical-item style="height: 50px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       `);
     }, () => {
@@ -309,16 +309,16 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
     hbs`
       <div style="height: 100px;" class="scrollable">
         <div style="padding-top: 400px;">
-          {{#vertical-collection this.items
-            containerSelector=".scrollable"
-            estimateHeight=20
-            bufferSize=2
+          <VerticalCollection @items={{this.items}}
+            @containerSelector=".scrollable"
+            @estimateHeight={{20}}
+            @bufferSize={{2}}
 
-            as |item i|}}
+            as |item i|>
             <vertical-item style="height: 20px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,
@@ -343,11 +343,11 @@ module('vertical-collection', 'Integration | Basic Tests', function(hooks) {
         <div style="height: 1000px; width: 500px;"></div>
 
         {{#if this.renderCollection}}
-          {{#vertical-collection this.items estimateHeight="20" as |item|}}
+          <VerticalCollection @items={{this.items}} @estimateHeight="20" as |item|>
             <div>
               Content
             </div>
-          {{/vertical-collection}}
+          </VerticalCollection>
         {{/if}}
       </div>
     `,

--- a/tests/integration/measure-test.js
+++ b/tests/integration/measure-test.js
@@ -147,15 +147,15 @@ module('vertical-collection', 'Integration | Measure Tests', function(hooks) {
     hbs`
       <div style="transform: scale(0.333333)">
         <div style="height: 100px" class="scrollable">
-          {{#vertical-collection this.items
-            estimateHeight=20
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @estimateHeight={{20}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <vertical-item style="height: 30px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,

--- a/tests/integration/measurement-unit-test.js
+++ b/tests/integration/measurement-unit-test.js
@@ -23,16 +23,16 @@ module('vertical-collection', 'Integration | Measurement Unit Tests', function(h
 
     hbs`
       <div style="height: 100px; font-size: 10px;" class="scrollable">
-        {{#vertical-collection this.items
-          estimateHeight="2em"
-          staticHeight=this.staticHeight
-          bufferSize=0
+        <VerticalCollection @items={{this.items}}
+          @estimateHeight="2em"
+          @staticHeight={{this.staticHeight}}
+          @bufferSize={{0}}
 
-          as |item i|}}
+          as |item i|>
           <vertical-item style="height: 2em">
             {{item.number}} {{i}}
           </vertical-item>
-        {{/vertical-collection}}
+        </VerticalCollection>
       </div>
     `,
 
@@ -47,16 +47,16 @@ module('vertical-collection', 'Integration | Measurement Unit Tests', function(h
 
     hbs`
       <div style="height: 100px; font-size: 10px;" class="scrollable">
-        {{#vertical-collection this.items
-          estimateHeight="2rem"
-          staticHeight=this.staticHeight
-          bufferSize=0
+        <VerticalCollection @items={{this.items}}
+          @estimateHeight="2rem"
+          @staticHeight={{this.staticHeight}}
+          @bufferSize={{0}}
 
-          as |item i|}}
+          as |item i|>
           <vertical-item style="height: 2rem">
             {{item.number}} {{i}}
           </vertical-item>
-        {{/vertical-collection}}
+        </VerticalCollection>
       </div>
     `,
 
@@ -71,16 +71,16 @@ module('vertical-collection', 'Integration | Measurement Unit Tests', function(h
 
     hbs`
       <div style="height: 100px;" class="scrollable">
-        {{#vertical-collection this.items
-          estimateHeight="66%"
-          staticHeight=this.staticHeight
-          bufferSize=0
+        <VerticalCollection @items={{this.items}}
+          @estimateHeight="66%"
+          @staticHeight={{this.staticHeight}}
+          @bufferSize={{0}}
 
-          as |item i|}}
+          as |item i|>
           <vertical-item style="height: 66%">
             {{item.number}} {{i}}
           </vertical-item>
-        {{/vertical-collection}}
+        </VerticalCollection>
       </div>
     `,
 
@@ -95,16 +95,16 @@ module('vertical-collection', 'Integration | Measurement Unit Tests', function(h
 
     hbs`
       <div style="height: 100px; font-size: 10px;" class="scrollable">
-        {{#vertical-collection this.items
-          estimateHeight="2em"
-          staticHeight=this.staticHeight
-          bufferSize=0
+        <VerticalCollection @items={{this.items}}
+          @estimateHeight="2em"
+          @staticHeight={{this.staticHeight}}
+          @bufferSize={{0}}
 
-          as |item i|}}
+          as |item i|>
           <vertical-item style="height: 2em">
             {{item.number}} {{i}}
           </vertical-item>
-        {{/vertical-collection}}
+        </VerticalCollection>
       </div>
     `,
 
@@ -120,17 +120,17 @@ module('vertical-collection', 'Integration | Measurement Unit Tests', function(h
     hbs`
       <div class="scrollable with-pixel-max-height">
         <div>
-          {{#vertical-collection this.items
-            containerSelector=".scrollable"
-            estimateHeight=20
-            staticHeight=this.staticHeight
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @containerSelector=".scrollable"
+            @estimateHeight={{20}}
+            @staticHeight={{this.staticHeight}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <vertical-item style="height: 20px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,
@@ -148,17 +148,17 @@ module('vertical-collection', 'Integration | Measurement Unit Tests', function(h
       <div style="height: 400px;">
         <div class="scrollable with-percent-max-height">
           <div>
-            {{#vertical-collection this.items
-              containerSelector=".scrollable"
-              estimateHeight=20
-              staticHeight=this.staticHeight
-              bufferSize=0
+            <VerticalCollection @items={{this.items}}
+              @containerSelector=".scrollable"
+              @estimateHeight={{20}}
+              @staticHeight={{this.staticHeight}}
+              @bufferSize={{0}}
 
-              as |item i|}}
+              as |item i|>
               <vertical-item style="height: 20px">
                 {{item.number}} {{i}}
               </vertical-item>
-            {{/vertical-collection}}
+            </VerticalCollection>
           </div>
         </div>
       </div>
@@ -177,17 +177,17 @@ module('vertical-collection', 'Integration | Measurement Unit Tests', function(h
       <div style="font-size: 20px;">
         <div class="scrollable with-em-max-height">
           <div>
-            {{#vertical-collection this.items
-              containerSelector=".scrollable"
-              estimateHeight=20
-              staticHeight=this.staticHeight
-              bufferSize=0
+            <VerticalCollection @items={{this.items}}
+              @containerSelector=".scrollable"
+              @estimateHeight={{20}}
+              @staticHeight={{this.staticHeight}}
+              @bufferSize={{0}}
 
-              as |item i|}}
+              as |item i|>
               <vertical-item style="height: 20px">
                 {{item.number}} {{i}}
               </vertical-item>
-            {{/vertical-collection}}
+            </VerticalCollection>
           </div>
         </div>
       </div>
@@ -205,17 +205,17 @@ module('vertical-collection', 'Integration | Measurement Unit Tests', function(h
     hbs`
       <div class="scrollable with-rem-max-height">
         <div>
-          {{#vertical-collection this.items
-            containerSelector=".scrollable"
-            estimateHeight=20
-            staticHeight=this.staticHeight
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @containerSelector=".scrollable"
+            @estimateHeight={{20}}
+            @staticHeight={{this.staticHeight}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <vertical-item style="height: 20px">
               {{item.number}} {{i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,

--- a/tests/integration/modern-ember-test.js
+++ b/tests/integration/modern-ember-test.js
@@ -12,12 +12,13 @@ module('vertical-collection', 'Integration | Modern Ember Features Tests', funct
 
     await render(hbs`
         <div class="scrollable">
-          {{#vertical-collection this.items
+          {{#vertical-collection
+            items=this.items
             estimateHeight=20
             staticHeight=true
           }}
-            {{else}}
-              Foobar
+          {{else}}
+            Foobar
           {{/vertical-collection}}
         </div>
       `);

--- a/tests/integration/recycle-test.js
+++ b/tests/integration/recycle-test.js
@@ -25,18 +25,18 @@ module('vertical-collection', 'Integration | Recycle Tests', function(hooks) {
     hbs`
       <div style="height: 200px" class="scrollable with-max-height">
         <div>
-          {{#vertical-collection this.items
-            containerSelector=".scrollable"
-            estimateHeight=20
-            staticHeight=this.staticHeight
-            shouldRecycle=false
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @containerSelector=".scrollable"
+            @estimateHeight={{20}}
+            @staticHeight={{this.staticHeight}}
+            @shouldRecycle={{false}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <vertical-item style="height: 20px">
               {{unbound item.number}} {{unbound i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,
@@ -59,18 +59,18 @@ module('vertical-collection', 'Integration | Recycle Tests', function(hooks) {
     hbs`
       <div style="height: 200px" class="scrollable">
         <div>
-          {{#vertical-collection this.items
-            containerSelector=".scrollable"
-            estimateHeight=20
-            staticHeight=this.staticHeight
-            shouldRecycle=true
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @containerSelector=".scrollable"
+            @estimateHeight={{20}}
+            @staticHeight={{this.staticHeight}}
+            @shouldRecycle={{true}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <vertical-item style="height: 20px">
               {{unbound item.number}} {{unbound i}}
             </vertical-item>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -72,6 +72,8 @@ module('vertical-collection', 'Integration | Scroll Tests', function(hooks) {
         count++;
         called();
       });
+
+      await settled();
     }
   );
 
@@ -98,6 +100,8 @@ module('vertical-collection', 'Integration | Scroll Tests', function(hooks) {
         count++;
         called();
       });
+
+      await settled();
     }
   );
 
@@ -309,6 +313,8 @@ module('vertical-collection', 'Integration | Scroll Tests', function(hooks) {
         assert.equal(index, 49, 'the lastReached item is correct');
         called();
       });
+
+      await settled();
     }
   );
 
@@ -404,18 +410,18 @@ module('vertical-collection', 'Integration | Scroll Tests', function(hooks) {
     <div style="height: 370px; width: 200px;" class="scrollable">
       <table class="table table-striped latest-data">
         <tbody>
-          {{#vertical-collection this.items
-            containerSelector=".scrollable"
-            estimateHeight=37
-            staticHeight=this.staticHeight
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @containerSelector=".scrollable"
+            @estimateHeight={{37}}
+            @staticHeight={{this.staticHeight}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <tr>
               <td>{{item.number}}</td>
               <td>{{i}}</td>
             </tr>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </tbody>
       </table>
     </div>
@@ -440,15 +446,15 @@ module('vertical-collection', 'Integration | Scroll Tests', function(hooks) {
     hbs`
       <div style="height: 200px; width: 200px;" class="scroll-parent scrollable">
         <div style="height: 400px; width: 100px;" class="scroll-child scrollable">
-          {{#vertical-collection this.items
-            estimateHeight=20
-            bufferSize=0
+          <VerticalCollection @items={{this.items}}
+            @estimateHeight={{20}}
+            @bufferSize={{0}}
 
-            as |item i|}}
+            as |item i|>
             <div class="vertical-item" style="height:40px;">
               {{item.number}} {{i}}
             </div>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,
@@ -470,15 +476,15 @@ module('vertical-collection', 'Integration | Scroll Tests', function(hooks) {
     hbs`
       <div style="height: 200px; width: 200px;" class="scroll-parent scrollable">
         <div style="height: 400px; width: 100px;" class="scroll-child scrollable">
-          {{#vertical-collection this.items
-            estimateHeight=20
-            bufferSize=0
-            registerAPI=(action this.registerAPI)
-            as |item i|}}
+          <VerticalCollection @items={{this.items}}
+            @estimateHeight={{20}}
+            @bufferSize={{0}}
+            @registerAPI={{this.registerAPI}}
+            as |item i|>
             <div class="vertical-item" style="height:40px;">
               {{item.number}} {{i}}
             </div>
-          {{/vertical-collection}}
+          </VerticalCollection>
         </div>
       </div>
     `,
@@ -490,7 +496,7 @@ module('vertical-collection', 'Integration | Scroll Tests', function(hooks) {
     },
     false,
     function() {
-      let registerAPI = function(collection) {
+      let registerAPI = collection => {
         this.set('collection', collection);
       };
       this.set('registerAPI', registerAPI);

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,7 +3,10 @@ import registerWaiter from 'ember-raf-scheduler/test-support/register-waiter';
 import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
+import QUnit from 'qunit';
 import { start } from 'ember-qunit';
+
+QUnit.config.testTimeout = 10000;
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
* Migrate to angle bracket invocation. This is supported natively in Ember 3.12, so should be a safe and good thing to do.
* Update the readme with the 4.x range
* Drop the position param argument for `items=`. This is a breaking change ahead of 4.0.