### PR TITLE
Fix for detached Node element exception

### DIFF
--- a/addon/-private/data-view/radar/radar.js
+++ b/addon/-private/data-view/radar/radar.js
@@ -539,6 +539,9 @@ export default class Radar {
           if (item) {
             insertRangeBefore(this._domPool, null, component.realUpperBound, component.realLowerBound);
           } else {
+            // Insert the virtual component bound back to make sure Glimmer is
+            // not confused about the state of the DOM.
+            insertRangeBefore(this._itemContainer, null, component.realUpperBound, component.realLowerBound);
             run(() => {
               virtualComponents.removeObject(component);
             });

--- a/tests/acceptance/acceptance-tests/record-array-test.js
+++ b/tests/acceptance/acceptance-tests/record-array-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 
 import { click, find, findAll, visit as newVisit } from '@ember/test-helpers';
+import scrollTo from '../../helpers/scroll-to';
 
 module('Acceptance | Record Array', function(hooks) {
   setupApplicationTest(hooks);
@@ -12,6 +13,42 @@ module('Acceptance | Record Array', function(hooks) {
     assert.equal(findAll('number-slide').length, 15, 'correct number of items rendered');
     assert.equal(find('number-slide:first-of-type').textContent.replace(/\s/g, ''), '0(0)', 'correct first item rendered');
     assert.equal(find('number-slide:last-of-type').textContent.replace(/\s/g, ''), '14(14)', 'correct last item rendered');
+  });
+
+  test('RecordArrays update correctly after scrolling and updating items', async function(assert) {
+    await newVisit('/acceptance-tests/record-array');
+
+    assert.equal(findAll('number-slide').length, 15, 'correct number of items rendered');
+
+    await scrollTo('.table-wrapper', 0, 600);
+
+    await click('#update-items-button');
+
+    assert.equal(findAll('number-slide').length, 5, 'correct number of items rendered');
+  });
+
+  test('RecordArrays update correctly after partial update', async function(assert) {
+    await newVisit('/acceptance-tests/record-array');
+
+    assert.equal(findAll('number-slide').length, 15, 'correct number of items rendered');
+
+    await click('#partial-update-button');
+
+    assert.equal(findAll('number-slide').length, 5, 'correct number of items rendered');
+  });
+
+  test('RecordArrays update correctly after being hidden and shown', async function(assert) {
+    await newVisit('/acceptance-tests/record-array');
+
+    assert.equal(findAll('number-slide').length, 15, 'correct number of items rendered');
+
+    await click('#hide-vc-button');
+
+    assert.equal(findAll('number-slide').length, 0, 'correct number of items rendered');
+
+    await click('#show-vc-button');
+
+    assert.equal(findAll('number-slide').length, 15, 'correct number of items rendered');
   });
 
   test('RecordArrays updates correctly after deleting items', async function(assert) {

--- a/tests/dummy/app/routes/acceptance-tests/record-array/controller.js
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/controller.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 export default Controller.extend({
   store: service(),
   prefixed: true,
+  vcShown: true,
 
   actions: {
     updateItems() {
@@ -11,8 +12,21 @@ export default Controller.extend({
       this.get('store').query('number-item', { length: 5 });
     },
 
+    partialUpdate() {
+      let length = this.model.content.length;
+      this.set('model', this.model.toArray().removeAt(0, length - 5));
+    },
+
     showPrefixed() {
       this.toggleProperty('prefixed');
+    },
+
+    hideVC() {
+      this.set('vcShown', false);
+    },
+
+    showVC() {
+      this.set('vcShown', true);
     }
   }
 });

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -1,11 +1,16 @@
-<div class="table-wrapper dark">
-  {{#vertical-collection this.model
-    estimateHeight=50
-    bufferSize=5
-    as |item index|}}
-    {{number-slide item=item itemIndex=index prefixed=this.prefixed}}
-  {{/vertical-collection}}
-</div>
+{{#if this.vcShown}}
+  <div class="table-wrapper dark">
+    {{#vertical-collection this.model
+      estimateHeight=50
+      bufferSize=5
+      as |item index|}}
+      {{number-slide item=item itemIndex=index prefixed=this.prefixed}}
+    {{/vertical-collection}}
+  </div>
+{{/if}}
 
+<button id="hide-vc-button" {{action "hideVC"}}>Hide VC</button>
+<button id="show-vc-button" {{action "showVC"}}>Show VC</button>
+<button id="partial-update-button" {{action "partialUpdate"}}>Partial Update</button>
 <button id="update-items-button" {{action "updateItems"}}>Update items</button>
 <button id="show-prefixed-button" {{action "showPrefixed"}}>Show prefixed</button>


### PR DESCRIPTION
Insert the virtual component bound back to make sure Glimmer is not confused about the state of the DOM resulting in `DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

I was unable to add a failing test for this but I have added a few test cases to improve test coverage and verified the fix in a consuming application.
