### PR TITLE
clear scheduled actions after recalculation

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -327,12 +327,19 @@ const VerticalCollection = Component.extend({
     _radar.bufferSize = this.bufferSize;
 
     _radar.scheduleUpdate(true);
+    this._clearScheduledActions();
 
     return _radar.virtualComponents;
   }),
 
   schedule(queueName, job) {
     return scheduler.schedule(queueName, job, this.token);
+  },
+
+  _clearScheduledActions() {
+    clearTimeout(this._nextSendActions);
+    this._nextSendActions = null;
+    this._scheduledActions.length = 0;
   },
 
   _scheduleSendAction(action, index) {

--- a/tests/dummy/app/routes/acceptance-tests/record-array/controller.js
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/controller.js
@@ -1,10 +1,14 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import { or } from '@ember/object/computed';
 
 export default Controller.extend({
   store: service(),
   prefixed: true,
   vcShown: true,
+  partial: undefined,
+  items: or('partial', 'model'),
+  firstVisibleId: undefined,
 
   actions: {
     updateItems() {
@@ -12,9 +16,13 @@ export default Controller.extend({
       this.store.query('number-item', { length: 5 });
     },
 
-    partialUpdate() {
-      let length = this.model.content.length;
-      this.set('model', this.model.toArray().removeAt(0, length - 5));
+    showLast(count) {
+      let length = this.model.length;
+      this.set('partial', this.model.slice(length - count));
+    },
+
+    showAll() {
+      this.set('partial', undefined);
     },
 
     showPrefixed() {
@@ -27,6 +35,10 @@ export default Controller.extend({
 
     showVC() {
       this.set('vcShown', true);
-    }
+    },
+
+    firstVisibleChanged(item) {
+      this.set('firstVisibleId', item.id);
+    },
   }
 });

--- a/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
+++ b/tests/dummy/app/routes/acceptance-tests/record-array/template.hbs
@@ -1,16 +1,24 @@
 {{#if this.vcShown}}
   <div class="table-wrapper dark">
-    <VerticalCollection @items={{this.model}}
+    <VerticalCollection
+      @key="id"
+      @items={{this.items}}
       @estimateHeight={{50}}
       @bufferSize={{5}}
-      as |item index|>
+      @firstVisibleChanged={{action "firstVisibleChanged"}}
+      as |item index|
+    >
       <NumberSlide @item={{item}} @itemIndex={{index}} @prefixed={{this.prefixed}} />
     </VerticalCollection>
   </div>
 {{/if}}
 
+<input id="first-visible-id" type="hidden" value={{this.firstVisibleId}}/>
+
 <button id="hide-vc-button" {{action "hideVC"}}>Hide VC</button>
 <button id="show-vc-button" {{action "showVC"}}>Show VC</button>
-<button id="partial-update-button" {{action "partialUpdate"}}>Partial Update</button>
+<button id="partial-update-button" {{action "showLast" 5}}>Show Last 5</button>
+<button id="last-25-button" {{action "showLast" 25}}>Show Last 25</button>
+<button id="show-all" {{action "showAll"}}>Show All</button>
 <button id="update-items-button" {{action "updateItems"}}>Update items</button>
-<button id="show-prefixed-button" {{action "showPrefixed"}}>Show prefixed</button>
+<button id="show-prefixed-button" {{action "showPrefixed"}}>Show prefixed (computed)</button>


### PR DESCRIPTION
Fixes https://github.com/html-next/vertical-collection/issues/317. Similar https://github.com/html-next/vertical-collection/pull/359 but using another approach + tests

Scheduled actions as the name says are fired with delay after the render is finished. They are going through the `sync` queue (`scheduleUpdate` method) and the `measure` queue (`update` method) in the radar class and `setTimeout` (`_scheduleSendAction` method) in the component. So there is some gap after the render is finished and before the event is actually fired when the `items` argument can be changed and the event will be fired with an exception. The scheduled actions include the event and index of the item, but due to timeout, the actual item may not exist for this index. 

Clear the timeout and the queue before scheduling a new update after recalculation to omit these outdated events and fire only the new actual events