### PR TITLE
Fix incorrect polling start

### DIFF
--- a/vertical-collection/addon/-private/data-view/utils/scroll-handler.js
+++ b/vertical-collection/addon/-private/data-view/utils/scroll-handler.js
@@ -50,11 +50,14 @@ export class ScrollHandler {
     }
 
     // TODO add explicit test
-    if (this.isUsingPassive && handlers.length === 1) {
-      element.addEventListener('scroll', cache.passiveHandler, {
-        capture: true,
-        passive: true,
-      });
+    if (this.isUsingPassive) {
+      // Only add the event listener once, if more handlers are present.
+      if (handlers.length === 1) {
+        element.addEventListener('scroll', cache.passiveHandler, {
+          capture: true,
+          passive: true,
+        });
+      }
 
       // TODO add explicit test
     } else if (!this.isPolling) {


### PR DESCRIPTION
The ScrollHandler has a bug where if multiple VerticalCollections are present in the same scrolling element, the polling behavior is started, even if passive event listeners are available. In this situation, both the listener and the polling are enabled, which probably results in some weird interactions. We noticed this issue in integration tests, because the polling does not play nice with the RAF test waiter (the tests hang forever).

The `if/else` branching made it easier to miss this bug, but the intention was most likely to only add the listener once, and only if passive listeners are available.

I'm not sure if any tests are warranted for this fix and to be honest I'm not really familiar with Embroider addons 😅 I fixed this in 4.0.2 on our fork and I'm porting the fix upstream so the bug doesn't go unnoticed.