### PR TITLE
Fix for #296: Insert the virtual component bound back to DOM also for the case `shouldRecycle=false`

### DIFF
--- a/vertical-collection/src/-private/data-view/radar/radar.js
+++ b/vertical-collection/src/-private/data-view/radar/radar.js
@@ -588,38 +588,33 @@ export default class Radar {
 
     // If there are any items remaining in the pool, remove them
     if (_componentPool.length > 0) {
-      if (shouldRecycle === true) {
-        // Grab the DOM of the remaining components and move it to temporary node disconnected from
-        // the body if the item can be reused later otherwise delete the component to avoid virtual re-rendering of the
-        // deleted item. If we end up using these components again, we'll grab their DOM and put it back
-        for (let i = _componentPool.length - 1; i >= 0; i--) {
-          const component = _componentPool[i];
-          const item = objectAt(items, component.index);
-          if (item) {
-            insertRangeBefore(
-              this._domPool,
-              null,
-              component.realUpperBound,
-              component.realLowerBound,
-            );
-          } else {
-            // Insert the virtual component bound back to make sure Glimmer is
-            // not confused about the state of the DOM.
-            insertRangeBefore(
-              this._itemContainer,
-              null,
-              component.realUpperBound,
-              component.realLowerBound,
-            );
-            run(() => {
-              virtualComponents.removeObject(component);
-            });
-            _componentPool.splice(i, 1);
-          }
+      // Grab the DOM of the remaining components and move it to temporary node disconnected from
+      // the body if the item can be reused later otherwise delete the component to avoid virtual re-rendering of the
+      // deleted item. If we end up using these components again, we'll grab their DOM and put it back
+      for (let i = _componentPool.length - 1; i >= 0; i--) {
+        const component = _componentPool[i];
+        const item = objectAt(items, component.index);
+        if (shouldRecycle === true && item) {
+          insertRangeBefore(
+            this._domPool,
+            null,
+            component.realUpperBound,
+            component.realLowerBound,
+          );
+        } else {
+          // Insert the virtual component bound back to make sure Glimmer is
+          // not confused about the state of the DOM.
+          insertRangeBefore(
+            this._itemContainer,
+            null,
+            component.realUpperBound,
+            component.realLowerBound,
+          );
+          run(() => {
+            virtualComponents.removeObject(component);
+          });
+          _componentPool.splice(i, 1);
         }
-      } else {
-        virtualComponents.removeObjects(_componentPool);
-        _componentPool.length = 0;
       }
     }
 


### PR DESCRIPTION
Fix for #296 race condition with `shouldRecycle=false` during fast scroll. 

The issue was that we had 'forgotten' to apply the fix 'Insert the virtual component bound back before removal to make sure Glimmer not confused about the state of the DOM.' also to the case `shouldRecycle=true`.

I was able to reproduce with scrolling fast up and down with the following component:

```glimmer-ts
// @ts-expect-error VerticalCollection is not typed yet
import VerticalCollection from '@html-next/vertical-collection/components/vertical-collection/component'

const projectList = [{id:'dd3gd'},{id:'yd3u5'},{id:'3d34'},{id:'hd3zx'},{id:'3d3h'},{id:'hd3ss'},{id:'3d3z'},{id:'zd319'},{id:'id371'},{id:'9d33x'},{id:'9d3b1'},{id:'3d35'},{id:'zd38d'},{id:'id3l9'},{id:'wd3g1'},{id:'hd3st'},{id:'9d3p9'},{id:'9d3i5'},{id:'id3e5'},{id:'id3sd'},{id:'id3zh'},{id:'jd3kt'},{id:'9d3wd'},{id:'hd3zw'},{id:'jd36l'},{id:'jd3dp'},{id:'zd3fh'},{id:'id370'},{id:'ad33h'},{id:'jd3rx'},{id:'wd3n5'},{id:'dd3ng'},{id:'dd3uk'},{id:'ed31o'},{id:'ed38s'},{id:'yd30x'},{id:'3d3v'},{id:'zd3tp'},{id:'zd3ml'},{id:'jd3z1'},{id:'xd38h'},{id:'id3e4'},{id:'3d3w'},{id:'kd3d9'},{id:'kd3kd'},{id:'kd365'},{id:'0d37x'},{id:'0d3f1'},{id:'ad3al'},{id:'0d3m5'},{id:'0d30t'}];

<template>
  <nav id='project-menu-nav' style='flex: 1; overflow: auto; height: 100%'>
    <VerticalCollection
      @items={{projectList}}
      @containerSelector='#project-menu-nav'
      @estimateHeight={{121}}
      @staticHeight={{true}}
      @shouldRecycle={{false}}
      @key='id'
      as |project|
    >
      <div style='width: 100%; height: 121px; border-bottom: 1px solid lightgray; box-sizing: border-box;'>
        {{project.id}}
      </div>
    </VerticalCollection>
  </nav>
</template>
```

Here the scroll window was 350 px height, it is more reproducible when it is small, and scrolling up and down very quickly:

https://github.com/user-attachments/assets/8eba910c-b80a-43fd-8456-0a760d334a58

