### PR TITLE
Replace ember-lts-6.4 and ember-lts-6.8 scenarios with ember-lts-6.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,7 @@ jobs:
           - ember-lts-3.28
           - ember-lts-4.12
           - ember-lts-5.12
-          - ember-lts-6.4
-          - ember-lts-6.8
+          - ember-lts-6.12
           - ember-release
           - ember-beta
           - ember-canary

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -40,18 +40,10 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-lts-6.4',
+        name: 'ember-lts-6.12',
         npm: {
           devDependencies: {
-            'ember-source': '~6.4.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-6.8',
-        npm: {
-          devDependencies: {
-            'ember-source': '~6.8.0',
+            'ember-source': '~6.12.0',
           },
         },
       },


### PR DESCRIPTION
## Summary

- Remove `ember-lts-6.4` and `ember-lts-6.8` try scenarios
- Add `ember-lts-6.12` try scenario (current LTS matching the test-app's ember-source version)

## Test plan

- [ ] All ember-try scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)