### PR TITLE
fix: add waiter token to _flush so settled() waits for pending RAF

### DIFF
--- a/vertical-collection/src/-private/utils/raf-scheduler.js
+++ b/vertical-collection/src/-private/utils/raf-scheduler.js
@@ -46,6 +46,7 @@ export class Scheduler {
     this.affect = [];
     this.jobs = 0;
     this._nextFlush = null;
+    this._flushToken = null;
     this.ticks = 0;
 
     if (DEBUG) {
@@ -80,6 +81,7 @@ export class Scheduler {
       return;
     }
 
+    this._flushToken = waiter.beginAsync();
     this._nextFlush = requestAnimationFrame(() => {
       this.flush();
     });
@@ -128,6 +130,7 @@ export class Scheduler {
     }
 
     this._nextFlush = null;
+    waiter.endAsync(this._flushToken);
     if (this.jobs > 0) {
       this._flush();
     }


### PR DESCRIPTION
## Summary

Fixes all 12 failing `Static PromiseArray` tests (some assertion failures, some 60s timeouts).

## Root cause

The `_flush()` method schedules work via `requestAnimationFrame` but had no test waiter token covering the RAF callback. When `settled()` polled for outstanding async work, it found no active waiter tokens during the gap between render and PromiseArray resolution, so it returned early — before the items were available.

## Fix

Add a `waiter.beginAsync()` token in `_flush()` when scheduling the RAF, and `waiter.endAsync()` in `flush()` after the work completes. This ensures `settled()` waits for any pending animation frame work.

## Test plan

- [x] All 348 tests pass locally (was 336/348 before fix)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)