### PR TITLE
fix: re-roll lockfile to resolve ember-raf-scheduler 0.5.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
     dependencies:
       '@html-next/vertical-collection':
         specifier: workspace:*
-        version: file:vertical-collection
+        version: link:../vertical-collection
       ember-raf-scheduler:
         specifier: 0.5.1
         version: 0.5.1(c8332dc3f90c0e60eb130a3a85f980b9)
@@ -1401,10 +1401,6 @@ packages:
   '@handlebars/parser@2.2.2':
     resolution: {integrity: sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==}
     engines: {node: ^18 || ^20 || ^22 || >=24}
-
-  '@html-next/vertical-collection@file:vertical-collection':
-    resolution: {directory: vertical-collection, type: directory}
-    engines: {node: '>= 18'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3370,10 +3366,6 @@ packages:
     peerDependencies:
       '@ember/test-helpers': '>=3.0.3'
       qunit: ^2.13.0
-
-  ember-raf-scheduler@0.3.0:
-    resolution: {integrity: sha512-i8JWQidNCX7n5TOTIKRDR0bnsQN9aJh/GtOJKINz2Wr+I7L7sYVhli6MFqMYNGKC9j9e6iWsznfAIxddheyEow==}
-    engines: {node: 12.* || 14.* || >= 16}
 
   ember-raf-scheduler@0.5.1:
     resolution: {integrity: sha512-VrTEFl64Txj7XZ95qlDxyhvNDPmOtqixV7OkmhoKhjHSIL+fnvkbYsGDhJHCFf6arLjs2FIZsMcyXUS/BbxFlA==}
@@ -8592,13 +8584,6 @@ snapshots:
 
   '@handlebars/parser@2.2.2': {}
 
-  '@html-next/vertical-collection@file:vertical-collection':
-    dependencies:
-      '@embroider/addon-shim': 1.10.2
-      ember-raf-scheduler: 0.3.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -11004,12 +10989,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
-      - supports-color
-
-  ember-raf-scheduler@0.3.0:
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
       - supports-color
 
   ember-raf-scheduler@0.5.1(c8332dc3f90c0e60eb130a3a85f980b9):


### PR DESCRIPTION
## Summary

Re-rolls the lockfile so the `vertical-collection` workspace package resolves `ember-raf-scheduler` to 0.5.1 instead of the stale 0.3.0.

Fixes the "Tests" job timeout in #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)