### PR TITLE
fix: account for collection offset in scrollToItem

### DIFF
--- a/vertical-collection/package.json
+++ b/vertical-collection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@html-next/vertical-collection",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "infinite-scroll, done right. done.",
   "keywords": [
     "occlusion",

--- a/vertical-collection/package.json
+++ b/vertical-collection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@html-next/vertical-collection",
-  "version": "5.0.6",
+  "version": "5.0.5",
   "description": "infinite-scroll, done right. done.",
   "keywords": [
     "occlusion",

--- a/vertical-collection/src/components/vertical-collection.gjs
+++ b/vertical-collection/src/components/vertical-collection.gjs
@@ -400,7 +400,7 @@ class VerticalCollection extends Component.extend({
     const { _radar } = this;
     // Getting the offset height from Radar
     let scrollTop = _radar.getOffsetForIndex(index);
-    _radar._scrollContainer.scrollTop = scrollTop;
+    _radar._scrollContainer.scrollTop = scrollTop + _radar._collectionOffset;
     // To scroll exactly to specified index, we are changing the prevIndex values to specified index
     _radar._prevFirstVisibleIndex = _radar._prevFirstItemIndex = index;
     // Components will be rendered after schedule 'measure' inside 'update' method.


### PR DESCRIPTION
Summary
Updates scrollToItem to include the collection offset when setting the scroll container’s scrollTop.

This ensures programmatic scrolling targets the correct item position when the collection is rendered with an offset within its scroll container.